### PR TITLE
Fixed bug preventing client for asking for __typename

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -251,9 +251,15 @@ func fieldURLs(schemas []*graphql.RemoteSchema, stripInternal bool) FieldURLMap 
 	for _, remoteSchema := range schemas {
 		// each type defined by the schema can be found at remoteSchema.URL
 		for name, typeDef := range remoteSchema.Schema.Types {
+
+			// if the type is part of the introspection (and can't be left up to the backing services)
 			if !strings.HasPrefix(typeDef.Name, "__") || !stripInternal {
+				// you can ask for __typename at any service that defines the type
+				locations.RegisterURL(name, "__typename", remoteSchema.URL)
+
 				// each field of each type can be found here
 				for _, fieldDef := range typeDef.Fields {
+
 					// if the field is not an introspection field
 					if !(name == "Query" && strings.HasPrefix(fieldDef.Name, "__")) {
 						locations.RegisterURL(name, fieldDef.Name, remoteSchema.URL)

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -313,6 +313,16 @@ func TestGateway(t *testing.T) {
 		}, res)
 	})
 
+	t.Run("Introspection field on services", func(t *testing.T) {
+		// compute the location of each field
+		locations := fieldURLs(sources, false)
+
+		// make sure we have entries for __typename at each service
+		userTypenameURLs, err := locations.URLFor("User", "__typename")
+		assert.Nil(t, err)
+		assert.Equal(t, []string{"url1", "url2"}, userTypenameURLs)
+	})
+
 	t.Run("Gateway fields", func(t *testing.T) {
 		// define a gateway field
 		viewerField := &QueryField{


### PR DESCRIPTION
This bug fixes an issue found by @jakubknejzlik that preventing queries from including `__typename`.

fixes #72 