### PR TITLE
Add an option for setting location priorities

### DIFF
--- a/plan_test.go
+++ b/plan_test.go
@@ -1486,3 +1486,122 @@ func TestPlannerBuildQuery_node(t *testing.T) {
 func TestPlanQuery_mutationsInSeries(t *testing.T) {
 	t.Skip("Not implemented")
 }
+
+func TestPlanQuery_forcedPriorityResolution(t *testing.T) {
+	location1 := "url1"
+	location2 := "url2"
+
+	type testCase struct {
+		priorities       []string
+		allUsersLocation string
+		lastNameLocation string
+	}
+
+	// The location map for fields for this query.
+	// All fields live on location1. "lastName" is
+	// additionally available on location2.
+	locations := FieldURLMap{}
+	locations.RegisterURL("Query", "allUsers", location1)
+	locations.RegisterURL("User", "firstName", location1)
+	locations.RegisterURL("User", "lastName", location1)
+	locations.RegisterURL("User", "lastName", location2)
+
+	schema, _ := graphql.LoadSchema(`
+		type User {
+			firstName: String!
+			lastName: String!
+		}
+
+		type Query {
+			allUsers: [User!]!
+		}
+	`)
+
+	// plan function creates a plan based on the passed in priorities
+	plan := func(priorities []string) (QueryPlanList, error) {
+		planner := (&MinQueriesPlanner{}).WithLocationPriorities(priorities)
+
+		selections, err := planner.Plan(&PlanningContext{
+			Query: `
+				{
+					allUsers {
+						firstName
+						lastName
+					}
+				}
+			`,
+			Schema:    schema,
+			Locations: locations,
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("encountered error when planning query: %s", err.Error())
+		}
+
+		return selections, nil
+	}
+
+	// Test case 1:
+	//
+	// Plan with no manually defined priorities.
+	// locality rules dictate that "lastName" should
+	// be resolved at location1, since it is avaiable
+	// in both locations but the parent "allUsers"
+	// query only lives on location1.
+
+	selections, err := plan([]string{})
+	if err != nil {
+		t.Errorf("test setup failed: %s", err)
+		return
+	}
+
+	// There is only one root-level query (allUsers), so
+	// there should be only one step off the root
+	assert.Equal(t, 1, len(selections[0].RootStep.Then))
+	allUsersStep := selections[0].RootStep.Then[0]
+
+	assert.Equal(t, location1, allUsersStep.Queryer.(*graphql.SingleRequestQueryer).URL())
+
+	// All fields under allUsers can be resolved at the same
+	// location in this case, so there should be no next step.
+	allUsersField := graphql.SelectedFields(allUsersStep.SelectionSet)[0]
+	assert.Equal(t, "allUsers", allUsersField.Name)
+	assert.Equal(t, 0, len(allUsersStep.Then))
+
+	// Test case 2:
+	//
+	// Plan with manually defined priorities.
+	// location2 is prioritized over location1,
+	// so the planner should ignore locality and
+	// resolve lastName at location 2.
+
+	selections, err = plan([]string{location2})
+	if err != nil {
+		t.Errorf("test setup failed: %s", err)
+		return
+	}
+
+	// There is only one root-level query (allUsers), so
+	// there should be only one step off the root
+	assert.Equal(t, 1, len(selections[0].RootStep.Then))
+	allUsersStep = selections[0].RootStep.Then[0]
+
+	assert.Equal(t, location1, allUsersStep.Queryer.(*graphql.SingleRequestQueryer).URL())
+
+	allUsersField = graphql.SelectedFields(allUsersStep.SelectionSet)[0]
+	assert.Equal(t, "allUsers", allUsersField.Name)
+
+	// lastName will be resolved on location2, due to the
+	// priorities list, so there should be another step
+	// to retrieve that field from the other location.
+	assert.Equal(t, 1, len(allUsersStep.Then))
+	lastNameStep := allUsersStep.Then[0]
+
+	// We should only be requesting "lastName" from the other location
+	lastNameSelections := graphql.SelectedFields(lastNameStep.SelectionSet)
+	assert.Equal(t, 1, len(lastNameSelections))
+
+	lastNameField := lastNameSelections[0]
+	assert.Equal(t, "lastName", lastNameField.Name)
+	assert.Equal(t, location2, lastNameStep.Queryer.(*graphql.SingleRequestQueryer).URL())
+}


### PR DESCRIPTION
This adds a `WithLocationPriorities` option to the gateway.

Without the location priorities option, when a field is resolvable in more than one location (ie by more than one service), the default is to prefer a service by locality, such that child fields are resolved at the same location as their parent whenever possible. This avoids unnecessary network hops.

However, for cases like A/B testing, it is sometimes desirable to force the resolution of a field at a specific location/service. To satisfy this, the `WithLocationPriorities` option is added, and allows the caller to specify that all fields resolvable at a specified location are resolved at that location, regardless of where the parent object is resolved.