### PR TITLE
Fix bug with null result for federated objects

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -368,6 +368,16 @@ func executorFindInsertionPoints(resultLock *sync.Mutex, targetPoints []string, 
 		// get the type of the object in question
 		selectionType := foundSelection.Definition.Type
 
+		if rootValue == nil {
+			if selectionType.NonNull {
+				err := fmt.Errorf("Received null for required field: %v", foundSelection.Name)
+				log.Warn(err)
+				return nil, err
+			} else {
+				return nil, nil
+			}
+		}
+
 		// if the type is a list
 		if selectionType.Elem != nil {
 			log.Debug("Selection should be a list")


### PR DESCRIPTION
**Problem**

I'm experiencing an issue with federation. I have a schema like the following:

```gql
# Service 1
type Parent {
  child: Child
}

type Child {
    id: ID!
}
```

```gql
type Child {
  id: ID!
  name: String!
}
```

When I make a request like this:

```gql
{
  parent("someid") {
    child {
      id
      name
    }
  }
}
```

It works if all parents have a child. However, if any one `child` field is null, then the result of the query is basically empty. No data. No error.

**Solution**

The MR detects the null root object and returns a nil insertionPoint list, so that we don't execute the next step for a null child.

It also validates that the field is nullable. If it's not, and the root object is null, then it triggers an error. In this case, the result is still empty. Unfortunately I haven't figured out how to solve that part yet, but I've at least added a warning log for it. It should be uncommon, as it means there is a bug in the queryer (it's returning null for non-nullable fields), but still it would be nice to return something like `"cannot return null for non-nullable field` to the caller.