### PR TITLE
fix list determination, do not look for `:` in element node id

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -502,6 +502,13 @@ func executorFindInsertionPoints(resultLock *sync.Mutex, targetPoints []string, 
 	return oldBranch, nil
 }
 
+func isListElement(path string) bool {
+	if hashLocation:=strings.Index(path,"#"); hashLocation>0 {
+		path = path[:hashLocation]
+	}
+	return strings.Contains(path, ":")
+}
+
 func executorExtractValue(source map[string]interface{}, resultLock *sync.Mutex, path []string) (interface{}, error) {
 	// a pointer to the objects we are modifying
 	var recent interface{} = source
@@ -509,7 +516,7 @@ func executorExtractValue(source map[string]interface{}, resultLock *sync.Mutex,
 
 	for i, point := range path[:] {
 		// if the point designates an element in the list
-		if strings.Contains(point, ":") {
+		if isListElement(point) {
 			pointData, err := executorGetPointData(point)
 			if err != nil {
 				return nil, err

--- a/execute_test.go
+++ b/execute_test.go
@@ -1942,6 +1942,8 @@ func TestExecutorGetPointData(t *testing.T) {
 		{"foo:2", &extractorPointData{Field: "foo", Index: 2, ID: ""}},
 		{"foo#3", &extractorPointData{Field: "foo", Index: -1, ID: "3"}},
 		{"foo:2#3", &extractorPointData{Field: "foo", Index: 2, ID: "3"}},
+		{"foo#Thing:1337", &extractorPointData{Field: "foo", Index: -1, ID: "Thing:1337"}},
+		{"foo:2#Thing:1337", &extractorPointData{Field: "foo", Index: 2, ID: "Thing:1337"}},
 	}
 
 	for _, row := range table {
@@ -2073,4 +2075,23 @@ func TestFindInsertionPoint_stitchIntoObject(t *testing.T) {
 
 func TestFindInsertionPoint_handlesNullObjects(t *testing.T) {
 	t.Skip("Not yet implemented")
+}
+
+func TestSingleObjectWithColonInID(t *testing.T) {
+	var source = make(map[string]interface{})
+	_ = json.Unmarshal([]byte(
+		// language=JSON
+		`{"hello": {"id": "Thing:1337", "firstName": "Foo", "lastName": "bar"}}`),
+		&source,
+	)
+
+	value, err := executorExtractValue(source, &sync.Mutex{}, []string{"hello#Thing:1337"})
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	assert.Equal(t, map[string]interface{}{
+		"id": "Thing:1337", "firstName": "Foo", "lastName": "bar",
+	}, value)
 }


### PR DESCRIPTION
This fixes https://github.com/nautilus/gateway/issues/115

For Non-List results, the if block for deciding between list and single object relied on searching the path for `:`. This fails for object names that contains `:`.

The fix only looks for `:` in the non-Object part of the name