### PR TITLE
Remove check for same set of interfaces per type on schema merge

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -232,11 +232,6 @@ func mergeObjectTypes(schema *ast.Schema, previousDefinition *ast.Definition, ne
 
 	}
 
-	// make sure the 2 implement the same number of interfaces
-	if err := mergeStringSliceEquivalent(previousDefinition.Interfaces, newDefinition.Interfaces); err != nil {
-		return fmt.Errorf("object type does not implement a consistent set of interfaces. %s", err.Error())
-	}
-
 	// make sure that the 2 directive lists are the same
 	if err := mergeDirectiveListsEqual(previousDefinition.Directives, newDefinition.Directives); err != nil {
 		return err

--- a/merge_test.go
+++ b/merge_test.go
@@ -266,23 +266,6 @@ func TestMergeSchema_objectTypes(t *testing.T) {
 			`,
 		},
 		{
-			"Conflicting Implements",
-			`
-				interface Foo {
-					firstName: String
-				}
-
-				type User implements Foo {
-					firstName: String
-				}
-			`,
-			`
-				type User {
-					firstName: String
-				}
-			`,
-		},
-		{
 			"Conflicting declaration directives",
 			`
 				directive @foo(url: String!) on OBJECT

--- a/merge_test.go
+++ b/merge_test.go
@@ -922,3 +922,56 @@ func testMergeSchemas(t *testing.T, schema1 *ast.Schema, schema2Str string) (*as
 
 	return gateway.schema, err
 }
+
+func TestMergeSchemaDifferentSetsOfInterfaces(t *testing.T) {
+	// Thing of schema1 implements one interface
+	// Thing of schema2 implements two interfaces
+
+	schema1, err := graphql.LoadSchema(
+		//language=GRAPHQL
+		`
+		type Query {
+			node(id: ID!): Node
+			Thing(id: ID!): Thing
+		}
+
+		interface Node {
+			id: ID!
+		}
+				
+		type Thing implements Node {
+			id: ID!
+			foo: String!
+		}
+	`)
+	assert.Nil(t, err)
+	schema2, err := graphql.LoadSchema(
+		//language=GRAPHQL
+		`
+		type Query {
+			node(id: ID!): Node
+			Thing(id: ID!): Thing
+		}
+				
+		interface Node {
+			id: ID!
+		}
+		
+		interface MetaData {
+			created_at: String!
+		}
+		
+		type Thing implements Node & MetaData {
+			id: ID!
+			bar: String!
+			created_at: String!
+		}
+	`)
+	assert.Nil(t, err)
+
+	_, err = New([]*graphql.RemoteSchema{
+		{Schema: schema2, URL: "url1"},
+		{Schema: schema1, URL: "url2"},
+	})
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
this closes #117 

I removed a check completely - and also one test case of the testing table, that checks for this error.

I also added a new test to confirm, that the merge now works.