### PR TITLE
Make logger extendable

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -271,6 +271,13 @@ func WithLocationPriorities(priorities []string) Option {
 	}
 }
 
+// WithLogger returns an Option that sets the logger of the gateway
+func WithLogger(l Logger) Option {
+	return func(g *Gateway) {
+		log = l
+	}
+}
+
 var nodeField = &QueryField{
 	Name: "node",
 	Type: ast.NamedType("Node", &ast.Position{}),

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -139,6 +139,17 @@ func TestGateway(t *testing.T) {
 		assert.Equal(t, priorities, gateway.locationPriorities)
 	})
 
+	t.Run("WithLogger", func(t *testing.T) {
+		logger := &DefaultLogger{}
+		_, err := New(sources, WithLogger(logger))
+		if err != nil {
+			t.Error(err.Error())
+			return
+		}
+
+		assert.Equal(t, logger, log)
+	})
+
 	t.Run("fieldURLs ignore introspection", func(t *testing.T) {
 		locations := fieldURLs(sources, true)
 

--- a/logging.go
+++ b/logging.go
@@ -5,8 +5,18 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Logger handles the logging in the gateway library
-type Logger struct {
+// Logger logs messages
+type Logger interface {
+	Debug(args ...interface{})
+	Info(args ...interface{})
+	Warn(args ...interface{})
+
+	WithFields(fields LoggerFields) Logger
+	QueryPlanStep(step *QueryPlanStep)
+}
+
+// DefaultLogger handles the logging in the gateway library
+type DefaultLogger struct {
 	fields logrus.Fields
 }
 
@@ -14,7 +24,7 @@ type Logger struct {
 type LoggerFields map[string]interface{}
 
 // Debug should be used for any logging that would be useful for debugging
-func (l *Logger) Debug(args ...interface{}) {
+func (l *DefaultLogger) Debug(args ...interface{}) {
 	entry := newLogEntry()
 	// if there are fields
 	if l.fields != nil {
@@ -26,7 +36,7 @@ func (l *Logger) Debug(args ...interface{}) {
 }
 
 // Info should be used for any logging that doesn't necessarily need attention but is nice to see by default
-func (l *Logger) Info(args ...interface{}) {
+func (l *DefaultLogger) Info(args ...interface{}) {
 	entry := newLogEntry()
 	// if there are fields
 	if l.fields != nil {
@@ -38,7 +48,7 @@ func (l *Logger) Info(args ...interface{}) {
 }
 
 // Warn should be used for logging that needs attention
-func (l *Logger) Warn(args ...interface{}) {
+func (l *DefaultLogger) Warn(args ...interface{}) {
 	entry := newLogEntry()
 	// if there are fields
 	if l.fields != nil {
@@ -50,26 +60,26 @@ func (l *Logger) Warn(args ...interface{}) {
 }
 
 // WithFields adds the provided fields to the Log
-func (l *Logger) WithFields(fields LoggerFields) *Logger {
+func (l *DefaultLogger) WithFields(fields LoggerFields) Logger {
 	// build up the logrus fields
 	logrusFields := logrus.Fields{}
 	for key, value := range fields {
 		logrusFields[key] = value
 	}
-	return &Logger{fields: logrusFields}
+	return &DefaultLogger{fields: logrusFields}
 }
 
 // QueryPlanStep formats and logs a query plan step for human consumption
-func (l *Logger) QueryPlanStep(step *QueryPlanStep) {
-	log.WithFields(LoggerFields{
+func (l *DefaultLogger) QueryPlanStep(step *QueryPlanStep) {
+	l.WithFields(LoggerFields{
 		"id":              step.ParentID,
 		"insertion point": step.InsertionPoint,
 	}).Info(step.ParentType)
 
-	log.Info(graphql.FormatSelectionSet(step.SelectionSet))
+	l.Info(graphql.FormatSelectionSet(step.SelectionSet))
 }
 
-var log *Logger
+var log Logger = &DefaultLogger{}
 
 func newLogEntry() *logrus.Entry {
 	entry := logrus.New()
@@ -85,8 +95,4 @@ func newLogEntry() *logrus.Entry {
 	})
 
 	return logrus.NewEntry(entry)
-}
-func init() {
-	log = &Logger{}
-
 }


### PR DESCRIPTION
Extract a Logger interface so it can be customized by downstream dependencies.

Resolves: #122 