### PR TITLE
Fix data race when building insertion points

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -259,7 +259,9 @@ func executeStep(
 		// we need to find the ids of the objects we are inserting into and then kick of the worker with the right
 		// insertion point. For lists, insertion points look like: ["user", "friends:0", "catPhotos:0", "owner"]
 		for _, dependent := range step.Then {
-			insertPoints, err := executorFindInsertionPoints(resultLock, dependent.InsertionPoint, step.SelectionSet, queryResult, [][]string{insertionPoint}, step.FragmentDefinitions)
+			copiedInsertionPoint := make([]string, len(insertionPoint))
+			copy(copiedInsertionPoint, insertionPoint)
+			insertPoints, err := executorFindInsertionPoints(resultLock, dependent.InsertionPoint, step.SelectionSet, queryResult, [][]string{copiedInsertionPoint}, step.FragmentDefinitions)
 			if err != nil {
 				errCh <- err
 				return

--- a/execute_test.go
+++ b/execute_test.go
@@ -2095,3 +2095,181 @@ func TestSingleObjectWithColonInID(t *testing.T) {
 		"id": "Thing:1337", "firstName": "Foo", "lastName": "bar",
 	}, value)
 }
+
+// TestExecutor_plansWithManyDeepDependencies test that two `Then` works without races
+// Test provides quite deep query to illustrate problem with
+// reused memory during slice `appends`
+func TestExecutor_plansWithManyDeepDependencies(t *testing.T) {
+
+	// the query we want to execute is
+	//	{
+	//		user {						<- serviceA
+	//			parent {				<- serviceA
+	//				parent {			<- serviceA
+	//					id  			<- serviceA
+	//					house {			<- serviceB
+	//						address		<- serviceC
+	//						cats {		<- serviceC
+	//							id  	<- serviceC
+	//							name	<- serviceD
+	//						}
+	//					}
+	//				}
+	//			}
+	//		}
+	//	}
+
+	// test helpers
+	definitionFactory := func(s string) *ast.FieldDefinition {
+		return &ast.FieldDefinition{
+			Type: ast.NamedType(s, &ast.Position{}),
+		}
+	}
+	definitionListFactory := func(s string) *ast.FieldDefinition {
+		return &ast.FieldDefinition{
+			Type: ast.ListType(ast.NamedType(s, &ast.Position{}), &ast.Position{}),
+		}
+	}
+	idFieldFactory := func() *ast.Field {
+		return &ast.Field{
+			Name:       "id",
+			Definition: definitionFactory("ID"),
+		}
+	}
+
+	// build a query plan that the executor will follow
+	result, err := (&ParallelExecutor{}).Execute(&ExecutionContext{
+		RequestContext: context.Background(),
+		Plan: &QueryPlan{
+			RootStep: &QueryPlanStep{
+				Then: []*QueryPlanStep{
+					{
+						ParentType:     "Query",
+						InsertionPoint: []string{},
+						SelectionSet: ast.SelectionSet{
+							&ast.Field{
+								Name:       "user",
+								Definition: definitionFactory("User"),
+								SelectionSet: ast.SelectionSet{
+									&ast.Field{
+										Name:       "parent",
+										Definition: definitionFactory("User"),
+										SelectionSet: ast.SelectionSet{
+											&ast.Field{
+												Name:       "parent",
+												Definition: definitionFactory("User"),
+												SelectionSet: ast.SelectionSet{
+													idFieldFactory(),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						Queryer: &graphql.MockSuccessQueryer{
+							map[string]interface{}{
+								"user": map[string]interface{}{
+									"parent": map[string]interface{}{
+										"parent": map[string]interface{}{
+											"id": "1",
+										},
+									},
+								},
+							},
+						},
+						Then: []*QueryPlanStep{
+							{
+								ParentType:     "House",
+								InsertionPoint: []string{"user", "parent", "parent"},
+								SelectionSet: ast.SelectionSet{
+									&ast.Field{
+										Name:       "house",
+										Definition: definitionFactory("House"),
+										SelectionSet: ast.SelectionSet{
+											idFieldFactory(),
+											&ast.Field{
+												Name:       "cats",
+												Definition: definitionListFactory("Cat"),
+												SelectionSet: ast.SelectionSet{
+													idFieldFactory(),
+												},
+											},
+										},
+									},
+								},
+								Queryer: &graphql.MockSuccessQueryer{
+									map[string]interface{}{"node": map[string]interface{}{
+										"house": map[string]interface{}{
+											"id": "2",
+											"cats": []interface{}{
+												map[string]interface{}{"id": "3"},
+											},
+										},
+									}},
+								},
+								Then: []*QueryPlanStep{
+									{
+										ParentType:     "House",
+										InsertionPoint: []string{"user", "parent", "parent", "house"},
+										SelectionSet: ast.SelectionSet{
+											idFieldFactory(),
+											&ast.Field{
+												Name:       "address",
+												Definition: definitionFactory("String"),
+											},
+										},
+										Queryer: &graphql.MockSuccessQueryer{map[string]interface{}{
+											"node": map[string]interface{}{
+												"id": "2",
+												"address": "Cats street",
+											},
+										}}},
+									{
+										ParentType:     "User",
+										InsertionPoint: []string{"user", "parent", "parent", "house", "cats"},
+										SelectionSet: ast.SelectionSet{
+											idFieldFactory(),
+											&ast.Field{
+												Name:       "name",
+												Definition: definitionFactory("String"),
+											},
+										},
+										Queryer: &graphql.MockSuccessQueryer{map[string]interface{}{
+											"node": map[string]interface{}{
+												"id": "3", "name": "kitty",
+											}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Errorf("Encountered error executing plan: %v", err.Error())
+		return
+	}
+
+	// make sure we got the right values back
+	assert.NotNil(t, result)
+	assert.Equal(t, map[string]interface{}{
+		"user": map[string]interface{}{
+			"parent": map[string]interface{}{
+				"parent": map[string]interface{}{
+					"id": "1",
+					"house": map[string]interface{}{
+						"id": "2",
+						"address": "Cats street",
+						"cats": []interface{}{
+							map[string]interface{}{"id": "3", "name": "kitty"},
+						},
+					},
+				},
+			},
+		},
+	}, result)
+}


### PR DESCRIPTION
Data race happens when `executeStep` iterates over many `Then` steps.

Here that happens:
https://github.com/nautilus/gateway/blob/c001b083e6a63c18bbc23f5ada6fb14c81285085/execute.go#L262

`insertionPoint` re-used for many steps and new iteration of loop could affect previous, because `oldBranch` not copied in `executorFindInsertionPoints`. I think it happens somewhere there:
https://github.com/nautilus/gateway/blob/c001b083e6a63c18bbc23f5ada6fb14c81285085/execute.go#L453

`-race` flag catch this with warning on specific query:

```
WARNING: DATA RACE
Read at 0x00c00099a1f0 by goroutine 79:
  github.com/nautilus/gateway.executeStep()
      /Users/prokaktus/prg/repos/gateway/execute.go:175 +0x708

Previous write at 0x00c00099a1f0 by goroutine 67:
  github.com/nautilus/gateway.executorFindInsertionPoints()
      /Users/prokaktus/prg/repos/gateway/execute.go:463 +0x2144
  github.com/nautilus/gateway.executeStep()
      /Users/prokaktus/prg/repos/gateway/execute.go:265 +0x1ae0

Goroutine 79 (running) created at:
  github.com/nautilus/gateway.executeStep()
      /Users/prokaktus/prg/repos/gateway/execute.go:282 +0x2224

Goroutine 67 (finished) created at:
  github.com/nautilus/gateway.executeStep()
      /Users/prokaktus/prg/repos/gateway/execute.go:282 +0x2224
```

I create this PR as a Draft, because I want to try add test with example for that.