### PR TITLE
replace copy() with a "deeper" copy

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -401,7 +401,9 @@ func executorFindInsertionPoints(resultLock *sync.Mutex, targetPoints []string, 
 				log.Debug("Adding ", entryPoint, " to list")
 
 				newBranchSet := make([][]string, len(oldBranch))
-				copy(newBranchSet, oldBranch)
+				for i, c := range oldBranch {
+					newBranchSet[i] = append(newBranchSet[i], c...)
+				}
 
 				// if we are adding to an existing branch
 				if len(newBranchSet) > 0 {


### PR DESCRIPTION
replace copy() with "deeper" version of copying `[][]string`.

Caveats:
* no tests yet
* no much research yet, if there is a more elegant way

fixes #136 