### PR TITLE
Return null data when data is empty

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -89,6 +89,9 @@ func (g *Gateway) Execute(ctx *RequestContext, plans QueryPlanList) (map[string]
 	// execute the plan and return the results
 	result, err := g.executor.Execute(executionContext)
 	if err != nil {
+		if len(result) == 0 {
+			return nil, err
+		}
 		return result, err
 	}
 


### PR DESCRIPTION
We encountered an issue where the returned response data is replaced by an empty object when it's null. This happens when response code is `200` and an error is returned. Some libraries don't accept this and according to the [gql specs](http://spec.graphql.org/draft/#sec-Errors) data should be either null or populated `{}`.
 
Example : 
Backend returns this response to a query: 
```
{
  "data": null,
  "errors": [
    {
      "extensions": {
        "category": "client"
      },
      "message": "error message",
    }
  ]
}
```
You can see that in this case, `data` is `null`. Gateway then replaces that `null` with `{}` and returns this response : 
```
{
  "data": {},
  "errors": [
    {
      "extensions": {
        "category": "client"
      },
      "message": "error message",
    }
  ]
}
```
This pull request is meant to address that issue. Let me know what you think!

