### PR TITLE
Remove the internal schema as a package level var to fix race issues

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/99designs/gqlgen/graphql/introspection"
 	"github.com/mitchellh/mapstructure"
@@ -10,10 +9,6 @@ import (
 
 	"github.com/nautilus/graphql"
 )
-
-// internalSchema is a graphql schema that exists at the gateway level and is merged with the
-// other schemas that the gateway wraps.
-var internalSchema *ast.Schema
 
 // internalSchemaLocation is the location that functions should take to identify a remote schema
 // that points to the gateway's internal schema.
@@ -309,22 +304,4 @@ func (g *Gateway) introspectDirectiveSlice(directives []introspection.Directive,
 	}
 
 	return result
-}
-
-func init() {
-	// load the internal
-	schema, err := graphql.LoadSchema(`
-		interface Node {
-			id: ID!
-		}
-
-		type Query {
-			node(id: ID!): Node
-		}
-	`)
-	if schema == nil {
-		panic(fmt.Sprintf("Syntax error in schema string: %s", err.Error()))
-	}
-
-	internalSchema = schema
 }


### PR DESCRIPTION
Thanks a lot for Nautilus! I was recently refactoring our code and this internal schema was triggering the Go race detector when using the gateway in tests.

There is very little advantage to having the package level var from what I can see.