### PR TITLE
Build with Go 1.18, compatible with Go 1.13

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Use Go 1.13
-        uses: actions/setup-go@v1
+      - name: Use Go 1.18
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.13
+          go-version: 1.18.x
 
       - name: Checkout source
         uses: actions/checkout@master

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install runner and dependencies
         run: |
-          go get github.com/alecaivazis/run
+          go install github.com/alecaivazis/run@latest
           export PATH=${PATH}:`go env GOPATH`/bin
           run install:ci
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Use Go 1.13
-        uses: actions/setup-go@v1
+      - name: Use Go 1.18
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.13
+          go-version: 1.18.x
 
       - name: Checkout source
         uses: actions/checkout@master

--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ arguments to pass the executable, run `./gateway --help`.
 This project is built as a go module and follows the practices outlined in the [spec](https://github.com/golang/go/wiki/Modules). Please consider all APIs experimental and subject
 to change until v1 has been released at which point semantic versioning will be strictly followed. Before
 then, minor version bumps denote an API breaking change.
+
+Currently supports Go Modules using Go 1.13 and above.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/vektah/gqlparser/v2 v2.1.0
 	golang.org/x/net v0.0.0-20201002202402-0a1ea396d57c
-	golang.org/x/sys v0.0.0-20201005172224-997123666555 // indirect
+	golang.org/x/sys v0.0.0-20220614162138-6c1b26c55098 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201005172224-997123666555 h1:fihtqzYxy4E31W1yUlyRGveTZT1JIP0bmKaDZ2ceKAw=
 golang.org/x/sys v0.0.0-20201005172224-997123666555/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220614162138-6c1b26c55098 h1:PgOr27OhUx2IRqGJ2RxAWI4dJQ7bi9cSrB82uzFzfUA=
+golang.org/x/sys v0.0.0-20220614162138-6c1b26c55098/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190125232054-d66bd3c5d5a6/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190515012406-7d7faa4812bd/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=


### PR DESCRIPTION
* Bumps the Go version for builds to the latest, Go 1.18.
* Fixes golang.org/x/sys version for Go 1.18.
* The `go X.Y` line in go.mod enforces our backward compatibility guarantee. Documented in README now.