### PR TITLE
Use first non-empty description when merging

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -125,11 +125,13 @@ func (g *Gateway) internalSchema() (*ast.Schema, error) {
 
 	// then we have to add any query fields we have
 	for _, field := range g.queryFields {
-		schema.Query.Fields = append(schema.Query.Fields, &ast.FieldDefinition{
-			Name:      field.Name,
-			Type:      field.Type,
-			Arguments: field.Arguments,
-		})
+		if field.Name != "node" { // skip internal Query field name
+			schema.Query.Fields = append(schema.Query.Fields, &ast.FieldDefinition{
+				Name:      field.Name,
+				Type:      field.Type,
+				Arguments: field.Arguments,
+			})
+		}
 	}
 
 	// we're done

--- a/merge_test.go
+++ b/merge_test.go
@@ -1249,6 +1249,75 @@ type Query {
 }
 `,
 		},
+		{
+			name: "Conflicting argument descriptions",
+			schemas: []string{
+				`
+				type Foo {
+					name(
+						"description"
+						arg1: String
+					): String
+				}
+			`,
+				`
+				type Foo {
+					name(
+						"other-description"
+						arg1: String
+					): String
+				}
+			`,
+			},
+			expectSchema: `
+type Foo {
+	name("""
+	description
+	"""
+	arg1: String): String
+}
+interface Node {
+	id: ID!
+}
+type Query {
+	node(id: ID!): Node
+}
+`,
+		},
+		{
+			name: "Conflicting argument descriptions, first non-empty wins",
+			schemas: []string{
+				`
+				type Foo {
+					name(
+						arg1: String
+					): String
+				}
+			`,
+				`
+				type Foo {
+					name(
+						"description"
+						arg1: String
+					): String
+				}
+			`,
+			},
+			expectSchema: `
+type Foo {
+	name("""
+	description
+	"""
+	arg1: String): String
+}
+interface Node {
+	id: ID!
+}
+type Query {
+	node(id: ID!): Node
+}
+`,
+		},
 	} {
 		tc := tc // enable parallel sub-tests
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/nautilus/gateway/issues/143

Deterministically sets descriptions to the first non-empty value. A consistently ordered list of input schemas results in a consistently merged output schema.