### PR TITLE
Fix CI to work with Go 1.19

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.46.2
+          version: v1.50.1
 
   build:
     name: Build release binaries

--- a/execute_test.go
+++ b/execute_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"testing"
@@ -1471,7 +1471,7 @@ func TestExecutor_appliesRequestMiddlewares(t *testing.T) {
 			return &http.Response{
 				StatusCode: 200,
 				// Send response to be tested
-				Body: ioutil.NopCloser(bytes.NewBuffer(result)),
+				Body: io.NopCloser(bytes.NewBuffer(result)),
 				// Must be set to non-nil value or it panics
 				Header: make(http.Header),
 			}

--- a/http.go
+++ b/http.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -242,7 +242,7 @@ func parsePostRequest(r *http.Request) (operations []*HTTPOperation, batchMode b
 	switch contentType {
 	case "text/plain", "application/json", "":
 		// read the full request body
-		operationsJSON, err := ioutil.ReadAll(r.Body)
+		operationsJSON, err := io.ReadAll(r.Body)
 		if err != nil {
 			payloadErr = fmt.Errorf("encountered error reading body: %w", err)
 			return

--- a/http_test.go
+++ b/http_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -241,7 +240,7 @@ func readResultWithErrors(responseRecorder *httptest.ResponseRecorder, t *testin
 	t.Helper()
 	recorderResult := responseRecorder.Result()
 	defer recorderResult.Body.Close()
-	body, err := ioutil.ReadAll(recorderResult.Body)
+	body, err := io.ReadAll(recorderResult.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -471,7 +470,7 @@ func TestPlaygroundHandler_postRequest(t *testing.T) {
 	response := responseRecorder.Result()
 	defer response.Body.Close()
 	// read the body
-	_, err = ioutil.ReadAll(response.Body)
+	_, err = io.ReadAll(response.Body)
 	if err != nil {
 		t.Error(err.Error())
 		return
@@ -545,7 +544,7 @@ func TestPlaygroundHandler_postRequestList(t *testing.T) {
 	}
 
 	// read the body
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		t.Error(err.Error())
 		return

--- a/merge.go
+++ b/merge.go
@@ -663,30 +663,31 @@ func mergeTypesEqual(type1, type2 *ast.Type) error {
 // runtime error or an ignored execution directive instead of an immediate query syntax error.
 //
 // From the spec: http://spec.graphql.org/October2021/#DirectiveLocation
-//     DirectiveLocation :
-//     	ExecutableDirectiveLocation
-//     	TypeSystemDirectiveLocation
-//     ExecutableDirectiveLocation :
-//       QUERY
-//       MUTATION
-//       SUBSCRIPTION
-//       FIELD
-//       FRAGMENT_DEFINITION
-//       FRAGMENT_SPREAD
-//       INLINE_FRAGMENT
-//       VARIABLE_DEFINITION
-//     TypeSystemDirectiveLocation :
-//       SCHEMA
-//       SCALAR
-//       OBJECT
-//       FIELD_DEFINITION
-//       ARGUMENT_DEFINITION
-//       INTERFACE
-//       UNION
-//       ENUM
-//       ENUM_VALUE
-//       INPUT_OBJECT
-//       INPUT_FIELD_DEFINITION
+//
+//	DirectiveLocation :
+//		ExecutableDirectiveLocation
+//		TypeSystemDirectiveLocation
+//	ExecutableDirectiveLocation :
+//	  QUERY
+//	  MUTATION
+//	  SUBSCRIPTION
+//	  FIELD
+//	  FRAGMENT_DEFINITION
+//	  FRAGMENT_SPREAD
+//	  INLINE_FRAGMENT
+//	  VARIABLE_DEFINITION
+//	TypeSystemDirectiveLocation :
+//	  SCHEMA
+//	  SCALAR
+//	  OBJECT
+//	  FIELD_DEFINITION
+//	  ARGUMENT_DEFINITION
+//	  INTERFACE
+//	  UNION
+//	  ENUM
+//	  ENUM_VALUE
+//	  INPUT_OBJECT
+//	  INPUT_FIELD_DEFINITION
 func mergeDirectiveLocations(list1, list2 []ast.DirectiveLocation) ([]ast.DirectiveLocation, error) {
 	resultSet := make(map[ast.DirectiveLocation]struct{})
 	executableSet1 := make(map[ast.DirectiveLocation]struct{})


### PR DESCRIPTION
Fix CI to work with Go 1.19. Requires linter update and related fixes.