### PR TITLE
Fix panics on non-GET/non-POST requests

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -1469,7 +1469,7 @@ func TestGraphQLHandler_OptionsMethod(t *testing.T) {
 	response := httptest.NewRecorder()
 
 	gateway.GraphQLHandler(response, request)
-	assert.Equal(t,  http.StatusMethodNotAllowed, response.Code, "Unhandled HTTP method should return 405 Method Not Allowed, got:", response.Code)
+	assert.Equal(t, http.StatusMethodNotAllowed, response.Code, "Unhandled HTTP method should return 405 Method Not Allowed, got:", response.Code)
 	assert.JSONEq(t, `
 {
   "data": null,

--- a/http_test.go
+++ b/http_test.go
@@ -1449,6 +1449,7 @@ func TestStaticPlaygroundHandler(t *testing.T) {
 	})
 }
 
+// Conforms to working draft spec for GraphQL over HTTP: https://github.com/graphql/graphql-over-http/blob/e4540976487b77bc04f1b2ce5cc48a9beea49381/spec/GraphQLOverHTTP.md?plain=1#L205-L206
 func TestGraphQLHandler_OptionsMethod(t *testing.T) {
 	t.Parallel()
 	planner := &MockErrPlanner{Err: errors.New("Planning error")}


### PR DESCRIPTION
Stack trace from the original panic:
```
       panic: runtime error: index out of range [0] with length 0

goroutine 20 [running]:
testing.tRunner.func1.2({0x102910300, 0x140001682e8})
        src/testing/testing.go:1396 +0x1c8
testing.tRunner.func1()
        src/testing/testing.go:1399 +0x378
panic({0x102910300, 0x140001682e8})
        src/runtime/panic.go:884 +0x204
github.com/nautilus/gateway.(*Gateway).GraphQLHandler(0x1400015a100, {0x10293e208, 0x14000163540}, 0x1400015a300)
        gateway/http.go:150 +0x8c4
github.com/nautilus/gateway.TestGraphQLHandler_OptionsMethod(0x140001029c0)
        gateway/http_test.go:1470 +0x250
testing.tRunner(0x140001029c0, 0x102937a80)
        src/testing/testing.go:1446 +0x10c
created by testing.(*T).Run
        src/testing/testing.go:1493 +0x300
FAIL    github.com/nautilus/gateway     0.778s
FAIL
```
It failed to form a response because none had been created. This PR prevents further execution when the HTTP method is not supported.

The GraphQL over HTTP working draft [provides](https://github.com/graphql/graphql-over-http/blob/e4540976487b77bc04f1b2ce5cc48a9beea49381/spec/GraphQLOverHTTP.md?plain=1#L205-L206) a little bit of clarity here, though stops short of defining non-GET and non-POST response status codes.

Given most servers return 405 Method Not Allowed in these kinds of scenarios and it is certainly better than panicking (typically with a 500 error), I think this is the right move for now.