### PR TITLE
Bump Go to test latest, drop Go 1.16 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.52.2
 
   build:
     name: Build release binaries

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x  # Avoid latest here. New Go versions can break linters.
+          go-version: 1.20.x  # Avoid latest here. New Go versions can break linters.
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -27,7 +27,7 @@ jobs:
       - name: Use latest Go version
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version: ^1.20
 
       - name: Checkout source
         uses: actions/checkout@master
@@ -36,11 +36,7 @@ jobs:
 
       - name: Install runner and dependencies
         run: |
-          if [[ "$(go version)" =~ go1\.([0-9]+) ]] && (( "${BASH_REMATCH[1]}" >= 16 )); then
-              go install github.com/alecaivazis/run@latest
-          else
-              go get github.com/alecaivazis/run
-          fi
+          go install github.com/alecaivazis/run@latest
 
       - name: Build
         run: |
@@ -53,9 +49,10 @@ jobs:
     strategy:
       matrix:
         go:
-          - 1.16.x
           - 1.17.x
-          - ^1.18  # Latest version of Go
+          - 1.18.x
+          - 1.19.x
+          - ^1.20  # Latest version of Go
     steps:
       - name: Use Go ${{ matrix.go }}
         uses: actions/setup-go@v3
@@ -69,18 +66,14 @@ jobs:
 
       - name: Install runner and dependencies
         run: |
-          if [[ "$(go version)" =~ go1\.([0-9]+) ]] && (( "${BASH_REMATCH[1]}" >= 16 )); then
-              go install github.com/alecaivazis/run@latest
-          else
-              go get github.com/alecaivazis/run
-          fi
+          go install github.com/alecaivazis/run@latest
 
       - name: Run tests
         run: |
           run tests:coverage
 
       - name: Report to Coveralls
-        if: matrix.go == '^1.18'
+        if: matrix.go == '^1.20'
         uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: coverage.out

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,8 +35,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Install runner and dependencies
-        run: |
-          go install github.com/alecaivazis/run@latest
+        run: go install github.com/alecaivazis/run@latest
 
       - name: Build
         run: |
@@ -65,12 +64,10 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Install runner and dependencies
-        run: |
-          go install github.com/alecaivazis/run@latest
+        run: go install github.com/alecaivazis/run@latest
 
       - name: Run tests
-        run: |
-          run tests:coverage
+        run: run tests:coverage
 
       - name: Report to Coveralls
         if: matrix.go == '^1.20'

--- a/cache.go
+++ b/cache.go
@@ -57,7 +57,7 @@ func WithNoQueryPlanCache() Option {
 type NoQueryPlanCache struct{}
 
 // Retrieve just computes the query plan
-func (p *NoQueryPlanCache) Retrieve(ctx *PlanningContext, hash *string, planner QueryPlanner) (QueryPlanList, error) {
+func (p *NoQueryPlanCache) Retrieve(ctx *PlanningContext, _ *string, planner QueryPlanner) (QueryPlanList, error) {
 	return planner.Plan(ctx)
 }
 

--- a/execute.go
+++ b/execute.go
@@ -720,7 +720,7 @@ type ErrExecutor struct {
 }
 
 // Execute returns the internet error
-func (e *ErrExecutor) Execute(ctx *ExecutionContext) (map[string]interface{}, error) {
+func (e *ErrExecutor) Execute(_ *ExecutionContext) (map[string]interface{}, error) {
 	return nil, e.Error
 }
 
@@ -730,7 +730,7 @@ type MockExecutor struct {
 }
 
 // Execute returns the provided value
-func (e *MockExecutor) Execute(ctx *ExecutionContext) (map[string]interface{}, error) {
+func (e *MockExecutor) Execute(_ *ExecutionContext) (map[string]interface{}, error) {
 	return e.Value, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,23 @@
 module github.com/nautilus/gateway
 
+go 1.17
+
 require (
 	github.com/99designs/gqlgen v0.17.15
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/nautilus/graphql v0.0.20
-	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.7.1
 	github.com/vektah/gqlparser/v2 v2.4.8
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
-	golang.org/x/sys v0.0.0-20220614162138-6c1b26c55098 // indirect
 )
 
-go 1.16
+require (
+	github.com/agnivade/levenshtein v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/graph-gophers/dataloader v5.0.0+incompatible // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20220614162138-6c1b26c55098 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)


### PR DESCRIPTION

Bump Go to test latest, drop Go 1.16 support.
Go 1.16 is hitting some issues with golang.org/x/sys, so we'll need to drop it to fix vulnerabilities.
