### PR TITLE
Use Go's built-in cross compiler for GitHub Releases

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,7 +35,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Build
-        run: make build
+        run: make -j8 build  # '-j N' runs each build task in parallel.
 
   tests:
     name: Test with Go ${{ matrix.go }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/*
 .idea
+cover.out

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,26 @@ test:
 	go test -race -coverprofile=cover.out ./...
 	cd ./cmd/gateway && go test -v -race ./...
 
-.PHONY: install-deps
-install-deps:
-	# Install the necessary dependencies to run in CI.
-	go install github.com/mitchellh/gox@latest
-
-.PHONY: build
-build: install-deps
+.PHONY: build-setup
+build-setup:
+	# When building cmd/gateway in CI, always use the current version of the gateway.
 	set -ex; \
 		cd cmd/gateway; \
 		go mod edit -replace github.com/nautilus/gateway=../..; \
-		go mod download github.com/nautilus/gateway; \
-		gox -os="linux darwin windows" -arch=amd64 -output="../../bin/gateway_{{.OS}}_{{.Arch}}" -verbose .
+		go mod download github.com/nautilus/gateway
+	rm -rf bin && mkdir bin
+
+.PHONY: build
+build: build-linux build-darwin build-windows
+
+.PHONY: build-linux
+build-linux: build-setup
+	cd cmd/gateway && CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build -o ../../bin/gateway_linux_amd64 .
+
+.PHONY: build-darwin
+build-darwin: build-setup
+	cd cmd/gateway && CGO_ENABLED=0 GOOS=darwin  GOARCH=amd64 go build -o ../../bin/gateway_darwin_amd64 .
+
+.PHONY: build-windows
+build-windows: build-setup
+	cd cmd/gateway && CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o ../../bin/gateway_windows_amd64.exe .


### PR DESCRIPTION

Use Go's built-in cross compiler for GitHub Releases.

Drops `gox`, which appears to be unmaintained at present.
The builds are still built in parallel and could be templated further with Make if we need it later.
