### PR TITLE
Add parallel builds to the deploy job too

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -24,7 +24,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Build and deploy binaries
-        run: make build
+        run: make -j8 build  # '-j N' runs each build task in parallel.
 
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Add parallel builds to the deploy job too. Partial follow-up from #192, I forgot the `-j N` option for deploy.