### PR TITLE
Resolve Node IDs in dependent steps & run response middleware on partial success

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -256,16 +256,12 @@ func executeOneStep(
 	}
 
 	// fire the query
-	err := queryer.Query(ctx.RequestContext, &graphql.QueryInput{
+	queryErr := queryer.Query(ctx.RequestContext, &graphql.QueryInput{
 		Query:         step.QueryString,
 		QueryDocument: step.QueryDocument,
 		Variables:     variables,
 		OperationName: operationName,
 	}, &queryResult)
-	if err != nil {
-		ctx.logger.Warn("Network Error: ", err)
-		return queryResult, nil, err
-	}
 
 	// NOTE: this insertion point could point to a list of values. If it did, we have to have
 	//       passed it to the this invocation of this function. It is safe to trust this
@@ -313,7 +309,7 @@ func executeOneStep(
 			}
 		}
 	}
-	return queryResult, dependentSteps, nil
+	return queryResult, dependentSteps, queryErr
 }
 
 func max(a, b int) int {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -754,6 +754,7 @@ type User {
 	`, resp.Body.String())
 }
 
+// TestDataAndErrorsBothReturnFromOneServicePartialSuccess verifies fix for https://github.com/nautilus/gateway/issues/212
 func TestDataAndErrorsBothReturnFromOneServicePartialSuccess(t *testing.T) {
 	t.Parallel()
 	schema, err := graphql.LoadSchema(`
@@ -795,6 +796,108 @@ type Query {
 				{
 					"message": "bar is broken",
 					"path": ["bar"],
+					"extensions": null
+				}
+			]
+		}
+	`, resp.Body.String())
+}
+
+// TestPartialSuccessAlsoResolvesValidNodeIDs verifies fix for https://github.com/nautilus/gateway/issues/214
+func TestPartialSuccessAlsoResolvesValidNodeIDs(t *testing.T) {
+	t.Parallel()
+	schemaFoo, err := graphql.LoadSchema(`
+type Query {
+	foo: Foo
+}
+
+type Foo {
+	bar: Bar
+	boo: String
+}
+
+interface Node {
+	id: ID!
+}
+
+type Bar implements Node {
+	id: ID!
+}
+`)
+	require.NoError(t, err)
+	schemaBar, err := graphql.LoadSchema(`
+type Query {
+	node(id: ID!): Node
+}
+
+interface Node {
+	id: ID!
+}
+
+type Bar implements Node {
+	id: ID!
+	baz: String
+}
+`)
+	require.NoError(t, err)
+	const query = `
+		query {
+			foo {
+				bar {
+					baz
+				}
+			}
+		}
+	`
+	queryerFactory := QueryerFactory(func(ctx *PlanningContext, url string) graphql.Queryer {
+		return graphql.QueryerFunc(func(input *graphql.QueryInput) (interface{}, error) {
+			t.Log("Received request:", input.Query)
+			if strings.Contains(input.Query, "node(") {
+				return map[string]interface{}{
+					"node": map[string]interface{}{
+						"baz": "biff",
+					},
+				}, nil
+			}
+			return map[string]interface{}{
+					"foo": map[string]interface{}{
+						"bar": map[string]interface{}{
+							"id": "bar-id",
+						},
+						"boo": nil,
+					},
+				}, graphql.ErrorList{
+					&graphql.Error{
+						Message: "boo is broken",
+						Path:    []interface{}{"foo", "boo"},
+					},
+				}
+		})
+	})
+	gateway, err := New([]*graphql.RemoteSchema{
+		{Schema: schemaFoo, URL: "foo"},
+		{Schema: schemaBar, URL: "bar"},
+	}, WithQueryerFactory(&queryerFactory))
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(fmt.Sprintf(`{"query": %q}`, query)))
+	resp := httptest.NewRecorder()
+	gateway.GraphQLHandler(resp, req)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.JSONEq(t, `
+		{
+			"data": {
+				"foo": {
+					"bar": {
+						"baz": "biff"
+					},
+					"boo": null
+				}
+			},
+			"errors": [
+				{
+					"message": "boo is broken",
+					"path": ["foo", "boo"],
 					"extensions": null
 				}
 			]


### PR DESCRIPTION
* Add failing test for partial success with unresolved Node IDs
* Resolve Node IDs in dependent steps, even on partial successes
* Add failing test for partial success not scrubbing unrequested fields from response
* Fix builtin middleware not running on partial success

Fixes https://github.com/nautilus/gateway/issues/214