### PR TITLE
Add Pre and Post execution hooks on the step executor level

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -27,7 +27,8 @@ type Gateway struct {
 	queryerFactory     *QueryerFactory
 	queryPlanCache     QueryPlanCache
 	locationPriorities []string
-
+	preExecutionHook   StepHook
+	postExecutionHook  StepHook
 	// group up the list of middlewares at startup to avoid it during execution
 	requestMiddlewares  []graphql.NetworkMiddleware
 	responseMiddlewares []ResponseMiddleware
@@ -86,6 +87,8 @@ func (g *Gateway) Execute(ctx *RequestContext, plans QueryPlanList) (map[string]
 		RequestMiddlewares: g.requestMiddlewares,
 		Plan:               plan,
 		Variables:          ctx.Variables,
+		PreExecutionHook:   g.preExecutionHook,
+		PostExecutionHook:  g.postExecutionHook,
 	}
 
 	// TODO: handle plans of more than one query
@@ -289,6 +292,20 @@ func WithQueryerFactory(factory *QueryerFactory) Option {
 func WithLocationPriorities(priorities []string) Option {
 	return func(g *Gateway) {
 		g.locationPriorities = priorities
+	}
+}
+
+// WithPreExecutionHook returns an Option that sets a pre-execution hook for all steps
+func WithPreExecutionHook(hook StepHook) Option {
+	return func(g *Gateway) {
+		g.preExecutionHook = hook
+	}
+}
+
+// WithPostExecutionHook returns an Option that sets a post-execution hook for all steps
+func WithPostExecutionHook(hook StepHook) Option {
+	return func(g *Gateway) {
+		g.postExecutionHook = hook
 	}
 }
 


### PR DESCRIPTION
Hello,

I added this functionality to enable some customization is specific cases. In our cases, we are trying to split a service, and to enable that we needed to have pre-execution hooks on the Step level to allow for the execution of intermediate operation during the migration.
I decided to make this into a proper PR, if you have any questions or changes requested please let me know