### PR TITLE
Prevent sending union type to wrong service, only query union subselection

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -426,11 +426,8 @@ func (p *MinQueriesPlanner) extractSelection(ctx *PlanningContext, config *extra
 					// > GraphQL Unions represent an object that could be one of a list of GraphQL Object types, but provides for no guaranteed fields between those types.
 					// > - https://spec.graphql.org/October2021/#sec-Unions
 					//
-					// So union selections must collapse into selected fragments on the union's named types.
-					// Importantly, unions can include shared types across schemas (union Foo = Bar | Baz; type Bar {...}; type Baz {...})
-					// but not all schemas need to contain the union (just: type Bar {...}).
-					//
-					// Therefore, union type names must not be queried as a "parent type". We can use their type conditions instead.
+					// Service schemas may not define a union type containing one of their shared types, and querying it on that service would result in an error.
+					// For these cases, union selections MUST collapse into selected fragments on the union's named types.
 					for _, subSelection := range selection.SelectionSet {
 						switch subSelection := subSelection.(type) {
 						case *ast.InlineFragment:

--- a/plan.go
+++ b/plan.go
@@ -419,28 +419,58 @@ func (p *MinQueriesPlanner) extractSelection(ctx *PlanningContext, config *extra
 				}
 
 				ctx.Gateway.logger.Debug("found a thing with a selection. extracting to ", insertionPoint, ". Parent insertion", config.insertionPoint)
-				// add any possible selections provided by this fields selections
-				subSelection, err := p.extractSelection(ctx, &extractSelectionConfig{
-					stepCh:         config.stepCh,
-					stepWg:         config.stepWg,
-					step:           config.step,
-					locations:      config.locations,
-					parentLocation: config.parentLocation,
-					plan:           config.plan,
+				typeName := coreFieldType(selection).Name()
+				subSelectionTypes := make(map[string]ast.SelectionSet)
+				if ctx.Schema.Types[typeName].Kind == ast.Union {
+					// Union types MUST be object types, and can't have fields of their own:
+					// > GraphQL Unions represent an object that could be one of a list of GraphQL Object types, but provides for no guaranteed fields between those types.
+					// > - https://spec.graphql.org/October2021/#sec-Unions
+					//
+					// So union selections must collapse into selected fragments on the union's named types.
+					// Importantly, unions can include shared types across schemas (union Foo = Bar | Baz; type Bar {...}; type Baz {...})
+					// but not all schemas need to contain the union (just: type Bar {...}).
+					//
+					// Therefore, union type names must not be queried as a "parent type". We can use their type conditions instead.
+					for _, subSelection := range selection.SelectionSet {
+						switch subSelection := subSelection.(type) {
+						case *ast.InlineFragment:
+							subSelectionTypes[subSelection.TypeCondition] = append(subSelectionTypes[subSelection.TypeCondition], subSelection.SelectionSet...)
+						case *ast.FragmentSpread:
+							fragment := config.step.FragmentDefinitions.ForName(selection.Name)
+							subSelectionTypes[fragment.TypeCondition] = append(subSelectionTypes[fragment.TypeCondition], fragment.SelectionSet...)
+						default:
+							return nil, fmt.Errorf("unsupported selection type inside union: %T", subSelection)
+						}
+					}
+				} else {
+					subSelectionTypes[typeName] = selection.SelectionSet
+				}
+				var subSelections ast.SelectionSet
+				for typeName, selectionSet := range subSelectionTypes {
+					// add any possible selections provided by this fields selections
+					subSelection, err := p.extractSelection(ctx, &extractSelectionConfig{
+						stepCh:         config.stepCh,
+						stepWg:         config.stepWg,
+						step:           config.step,
+						locations:      config.locations,
+						parentLocation: config.parentLocation,
+						plan:           config.plan,
 
-					parentType:     coreFieldType(selection).Name(),
-					selection:      selection.SelectionSet,
-					insertionPoint: insertionPoint,
-					wrapper:        wrapper,
-				})
-				if err != nil {
-					return nil, err
+						parentType:     typeName,
+						selection:      selectionSet,
+						insertionPoint: insertionPoint,
+						wrapper:        wrapper,
+					})
+					if err != nil {
+						return nil, err
+					}
+					subSelections = append(subSelections, subSelection...)
 				}
 
-				ctx.Gateway.logger.Debug(fmt.Sprintf("final selection for %s.%s: %v\n", config.parentType, selection.Name, subSelection))
+				ctx.Gateway.logger.Debug(fmt.Sprintf("final selection for %s.%s: %v\n", config.parentType, selection.Name, subSelections))
 
 				// overwrite the selection set for this selection
-				selection.SelectionSet = subSelection
+				selection.SelectionSet = subSelections
 			} else {
 				ctx.Gateway.logger.Debug("found a scalar")
 			}

--- a/plan_test.go
+++ b/plan_test.go
@@ -2,6 +2,8 @@ package gateway
 
 import (
 	"fmt"
+	"iter"
+	"strings"
 	"testing"
 
 	"github.com/nautilus/graphql"
@@ -1839,4 +1841,107 @@ func TestPlanQuery_inlineFragmentFieldsRespectParentLocation(t *testing.T) {
 	queryer := step.Queryer.(*graphql.SingleRequestQueryer)
 	assert.Equal(t, location1, queryer.URL(), "field bar on inline fragment should be routed to location1")
 	assert.Empty(t, step.Then, "should have no dependent sub-steps — all fields should stay on location1")
+}
+
+func TestPlanQuery_unionShouldNotBeQueriedOnOtherServices(t *testing.T) {
+	t.Parallel()
+	schema, err := graphql.LoadSchema(`
+		type Query {
+			foo: Foo!  # Only in location1
+			node(id: ID!): Node
+		}
+		union Foo = Bar | Baz  # Only in location1
+		interface Node {
+			id: ID!
+		}
+		type Bar implements Node {
+			id: ID!
+			bar: String!  # Only in location0
+		}
+		type Baz implements Node {
+			id: ID!
+		}
+	`)
+	require.NoError(t, err)
+
+	const (
+		location0 = "url0"
+		location1 = "url1"
+	)
+	locations := FieldURLMap{}
+	// location0 registers all shared types (Bar, Baz) but no unions
+	locations.RegisterURL(typeNameQuery, "node", location0)
+	locations.RegisterURL("Node", "id", location0)
+	locations.RegisterURL("Bar", "id", location0)
+	locations.RegisterURL("Bar", "bar", location0) // unique to location0
+	locations.RegisterURL("Baz", "id", location0)
+
+	// location1 registers foo union-typed 'Foo' field and all shared types (Bar, Baz)
+	locations.RegisterURL(typeNameQuery, "node", location1)
+	locations.RegisterURL(typeNameQuery, "foo", location1) // unique to location1
+	locations.RegisterURL("Node", "id", location1)
+	locations.RegisterURL("Bar", "id", location1)
+	locations.RegisterURL("Baz", "id", location1)
+
+	plans, err := (&MinQueriesPlanner{}).Plan(&PlanningContext{
+		Query: `
+			query {
+				foo {
+					... on Bar {
+						bar
+					}
+				}
+			}
+		`,
+		Schema:    schema,
+		Locations: locations,
+		Gateway:   &Gateway{logger: &DefaultLogger{}},
+	})
+	require.NoError(t, err)
+	require.Len(t, plans, 1)
+
+	rootSteps := plans[0].RootStep.Then
+	require.Len(t, rootSteps, 1, "should have exactly one root step")
+
+	for step := range allSteps(plans[0].RootStep) {
+		url := step.Queryer.(*graphql.SingleRequestQueryer).URL()
+		t.Logf("Found step on %q: %s", url, step.QueryString)
+		switch url {
+		case location0:
+			assert.NotContains(t, step.QueryString, "Foo", "Location 0 must not be called with 'Foo' union type")
+			assert.Equal(t, strings.TrimSpace(`
+query($id: ID!) {
+	node(id: $id) {
+		... on Bar {
+			bar
+		}
+	}
+}`), strings.TrimSpace(step.QueryString))
+		case location1:
+			assert.Equal(t, strings.TrimSpace(`
+query {
+	foo {
+		id
+	}
+}`), strings.TrimSpace(step.QueryString))
+		}
+	}
+}
+
+func allSteps(rootStep *QueryPlanStep) iter.Seq[*QueryPlanStep] {
+	return func(yield func(*QueryPlanStep) bool) {
+		allStepsRecursive(rootStep, yield)
+	}
+}
+
+func allStepsRecursive(step *QueryPlanStep, yield func(*QueryPlanStep) bool) bool {
+	if !yield(step) {
+		return false
+	}
+	for _, thenStep := range step.Then {
+		if !allStepsRecursive(thenStep, yield) {
+			return false
+		}
+	}
+	return true
 }

--- a/plan_test.go
+++ b/plan_test.go
@@ -1910,7 +1910,7 @@ func TestPlanQuery_unionShouldNotBeQueriedOnOtherServices(t *testing.T) {
 		case location0:
 			assert.NotContains(t, step.QueryString, "Foo", "Location 0 must not be called with 'Foo' union type")
 			assert.Equal(t, strings.TrimSpace(`
-query($id: ID!) {
+query ($id: ID!) {
 	node(id: $id) {
 		... on Bar {
 			bar


### PR DESCRIPTION
Follow-up to https://github.com/nautilus/gateway/pull/230

* Add failing test for sending union inline fragment to wrong service
* Collapse union selection set into one flat set of fragment subselections.

We can make this assumption because the GraphQL spec requires union types be object types:
> GraphQL Unions represent an object that could be one of a list of GraphQL Object types, but provides for no guaranteed fields between those types.
> – https://spec.graphql.org/October2021/#sec-Unions

