### PR TITLE
Fix interface not possible type when implementing another interface

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -71,6 +71,9 @@ func mergeSchemas(sources []*ast.Schema) (*ast.Schema, error) {
 				result.Types[name] = definition
 
 				result.AddPossibleType(name, definition)
+				for _, interfaceName := range definition.Interfaces {
+					result.AddPossibleType(interfaceName, definition)
+				}
 
 				// we're done with this definition
 				continue

--- a/merge_test.go
+++ b/merge_test.go
@@ -732,6 +732,52 @@ func TestMergeSchema_interfaces(t *testing.T) {
 		assert.True(t, visited["User"], "did not have User in possible type")
 		assert.True(t, visited["NotUser"], "did not have NotUser in possible type")
 	})
+	t.Run("Implements interface", func(t *testing.T) {
+		t.Parallel()
+		originalSchema, err := graphql.LoadSchema(`
+			interface Node {
+				id: ID!
+			}
+			interface Foo implements Node {
+				id: ID!
+				name: String!
+			}
+
+			type User implements Foo & Node {
+				id: ID!
+				name: String!
+			}
+		`)
+		require.NoError(t, err, "original schema didn't parse")
+
+		schema, err := testMergeSchemas(t, originalSchema, `
+			interface Node {
+				id: ID!
+			}
+
+			interface Foo implements Node {
+				id: ID!
+				name: String!
+			}
+
+			type NotUser implements Foo & Node {
+				id: ID!
+				name: String!
+			}
+		`)
+		require.NoError(t, err)
+
+		possibleTypes := func(typeName string) []string {
+			var types []string
+			for _, def := range schema.GetPossibleTypes(schema.Types[typeName]) {
+				types = append(types, def.Name)
+			}
+			return types
+		}
+
+		assert.ElementsMatch(t, []string{"Foo", "User", "NotUser"}, possibleTypes("Foo"))
+		assert.ElementsMatch(t, []string{"Node", "Foo", "User", "NotUser"}, possibleTypes("Node"))
+	})
 
 	// the table we are testing
 	testMergeRunNegativeTable(t, []testMergeTableRow{


### PR DESCRIPTION

Fix interface not possible type when implementing another interface

Some schemas may have interfaces that implement interfaces, like so:

```graphql
interface Node {
    id: ID!
}

interface Bar implements Node {
    id: ID!
}

type Foo implements Node & Bar {
    id: ID!
}
```

`Node` should be a possible type of `Bar`, just like `Node` and `Bar` are possible types of `Foo`.
