### PR TITLE
Allow merging some cases of unordered directives (built-in) with ordered directives (custom)

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -794,16 +794,9 @@ func mergeTypesEqual(type1, type2 *ast.Type) error {
 //	  INPUT_OBJECT
 //	  INPUT_FIELD_DEFINITION
 func mergeDirectiveLocations(list1, list2 []ast.DirectiveLocation) ([]ast.DirectiveLocation, error) {
-	executableSet1 := make(map[ast.DirectiveLocation]struct{})
-	for l := range potentialExecutableDirectiveLocations(list1) {
-		executableSet1[l] = struct{}{}
-	}
-	executableSet2 := make(map[ast.DirectiveLocation]struct{})
-	for l := range potentialExecutableDirectiveLocations(list2) {
-		executableSet2[l] = struct{}{}
-	}
-
-	if onlyLeft, onlyRight, areEqualSets := diffSets(executableSet1, executableSet2); !areEqualSets {
+	if onlyLeft, onlyRight, areEqualSets := diffSets(
+		potentialExecutableDirectiveLocations(list1),
+		potentialExecutableDirectiveLocations(list2)); !areEqualSets {
 		return nil, fmt.Errorf("do not have the same executable locations: exclusive to first = %v, exclusive to second = %v", onlyLeft, onlyRight)
 	}
 
@@ -865,14 +858,22 @@ func isTypeSystemDirectiveLocation(d ast.DirectiveLocation) bool {
 	}
 }
 
-func diffSets[Value comparable](left, right map[Value]struct{}) (onlyLeft, onlyRight []Value, areEqualSets bool) {
+func diffSets[Value comparable](left, right iter.Seq[Value]) (onlyLeft, onlyRight []Value, areEqualSets bool) {
+	leftSet := make(map[Value]struct{})
+	for l := range left {
+		leftSet[l] = struct{}{}
+	}
+	rightSet := make(map[Value]struct{})
+	for l := range right {
+		rightSet[l] = struct{}{}
+	}
 	for value := range left {
-		if _, alsoInRight := right[value]; !alsoInRight {
+		if _, alsoInRight := rightSet[value]; !alsoInRight {
 			onlyLeft = append(onlyLeft, value)
 		}
 	}
 	for value := range right {
-		if _, alsoInLeft := left[value]; !alsoInLeft {
+		if _, alsoInLeft := leftSet[value]; !alsoInLeft {
 			onlyRight = append(onlyRight, value)
 		}
 	}

--- a/merge.go
+++ b/merge.go
@@ -659,7 +659,19 @@ func mergeTypesEqual(type1, type2 *ast.Type) error {
 }
 
 // Directives can be used on execution locations (a query) or on type system locations (a deprecated field).
-// Gateway should not merge and share execution locations since these may not be supported by the respective service.
+//
+// Gateway should not merge and share *different sets* of execution locations since these may not be supported by the respective service. For example:
+//
+//	A:   on EXECUTABLE1 | EXECUTABLE2 | TYPESYSTEM1
+//	B:   on EXECUTABLE1 | TYPESYSTEM1
+//	A+B: Fails. Executable location sets are not equal.
+//
+// Equal sets of executable locations are permitted, for example:
+//
+//	A:   on EXECUTABLE1
+//	B:   on EXECUTABLE1 | TYPESYSTEM2
+//	A+B: on EXECUTABLE1 | TYPESYSTEM2
+//
 // Gateway should merge and share type system locations since these are only defined and used in each respective service's schema. In other words, the services own their usage of those directives.
 //
 // Some implementations merge all locations irrespective of their kind. This could result in a
@@ -694,7 +706,7 @@ func mergeTypesEqual(type1, type2 *ast.Type) error {
 func mergeDirectiveLocations(list1, list2 []ast.DirectiveLocation) ([]ast.DirectiveLocation, error) {
 	resultSet := make(map[ast.DirectiveLocation]struct{})
 	executableSet1 := make(map[ast.DirectiveLocation]struct{})
-	// Check the permissive set (type system locations) rather than the restrictive set (executable locations).
+	// Check "not in the permissive set" (type system locations) rather than the restrictive set (executable locations).
 	// The kinds of locations can expand in future versions of the spec, so we should err on the side
 	// of denying new type system fields instead of allowing new executable fields.
 	for _, l := range list1 {

--- a/merge.go
+++ b/merge.go
@@ -497,7 +497,9 @@ func mergeFields(field1, field2 *ast.FieldDefinition) (*ast.FieldDefinition, err
 // A directive list merge is compatible if any of the following conditions are met:
 //  1. One list is empty
 //  2. One list uses only built-in directives
-//  3. Both lists are identical
+//  3. Both lists' ordered directives are identical
+//
+// See [splitSignificantlyOrderedDirectives] for details on "ordered" directives.
 func mergeDirectiveLists(list1, list2 ast.DirectiveList) (ast.DirectiveList, error) {
 	ordered1, unordered1 := splitSignificantlyOrderedDirectives(list1)
 	ordered2, unordered2 := splitSignificantlyOrderedDirectives(list2)

--- a/merge.go
+++ b/merge.go
@@ -789,16 +789,6 @@ func isTypeSystemDirectiveLocation(d ast.DirectiveLocation) bool {
 	}
 }
 
-func executableDirectiveLocationDiff(set1, set2 map[ast.DirectiveLocation]struct{}) string {
-	var diff []string
-	for l := range set1 {
-		if _, ok := set2[l]; !ok {
-			diff = append(diff, string(l))
-		}
-	}
-	return fmt.Sprintf("these locations are not shared: %s", strings.Join(diff, ", "))
-}
-
 func diffSets[Value comparable](left, right map[Value]struct{}) (onlyLeft, onlyRight []Value, areEqualSets bool) {
 	for value := range left {
 		if _, alsoInRight := right[value]; !alsoInRight {

--- a/merge.go
+++ b/merge.go
@@ -507,7 +507,7 @@ func mergeDirectiveLists(list1, list2 ast.DirectiveList) (ast.DirectiveList, err
 
 	if len(list1) != len(list2) {
 		// they will never be the same
-		return nil, fmt.Errorf("there were an inconsistent number of directives: %d != %d", len(list1), len(list2))
+		return nil, fmt.Errorf("there were an inconsistent number of directives: %s != %s", formatDirectives(list1), formatDirectives(list2))
 	}
 
 	for index := range list1 {
@@ -801,4 +801,37 @@ func diffSets[Value comparable](left, right map[Value]struct{}) (onlyLeft, onlyR
 		}
 	}
 	return onlyLeft, onlyRight, len(onlyLeft) == 0 && len(onlyRight) == 0
+}
+
+func formatDirectives(directives ast.DirectiveList) string {
+	var directiveStrings []string
+	for _, d := range directives {
+		directiveStrings = append(directiveStrings, formatDirective(d))
+	}
+	return strings.Join(directiveStrings, " ")
+}
+
+func formatDirective(d *ast.Directive) string {
+	if d == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("@%s%s", d.Name, formatArgs(d.Arguments))
+}
+
+func formatArgs(args ast.ArgumentList) string {
+	if len(args) == 0 {
+		return ""
+	}
+	var argStrings []string
+	for _, arg := range args {
+		argStrings = append(argStrings, formatArg(arg))
+	}
+	return fmt.Sprintf("(%s)", strings.Join(argStrings, ", "))
+}
+
+func formatArg(arg *ast.Argument) string {
+	if arg == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%s: %s", arg.Name, arg.Value.String())
 }

--- a/merge.go
+++ b/merge.go
@@ -254,7 +254,9 @@ func mergeObjectTypes(previousDefinition *ast.Definition, newDefinition *ast.Def
 	}
 
 	// make sure that the 2 directive lists are the same
-	if err := mergeDirectiveListsEqual(previousDefinition.Directives, newDefinition.Directives); err != nil {
+	var err error
+	prevCopy.Directives, err = mergeDirectiveLists(previousDefinition.Directives, newDefinition.Directives)
+	if err != nil {
 		return nil, err
 	}
 
@@ -297,7 +299,8 @@ func mergeInputObjects(object1, object2 *ast.Definition) (*ast.Definition, error
 	}
 
 	// check directives
-	if err := mergeDirectiveListsEqual(object1.Directives, object2.Directives); err != nil {
+	object1Copy.Directives, err = mergeDirectiveLists(object1.Directives, object2.Directives)
+	if err != nil {
 		return nil, err
 	}
 
@@ -407,7 +410,9 @@ func mergeEnumValues(value1, value2 *ast.EnumValueDefinition) (*ast.EnumValueDef
 	}
 
 	// if the 2 directives dont match
-	if err := mergeDirectiveListsEqual(value1.Directives, value2.Directives); err != nil {
+	var err error
+	value1Copy.Directives, err = mergeDirectiveLists(value1.Directives, value2.Directives)
+	if err != nil {
 		return nil, fmt.Errorf("conflict in enum value directives: %w", err)
 	}
 
@@ -421,7 +426,9 @@ func mergeScalars(value1, value2 *ast.Definition) (*ast.Definition, error) {
 	}
 
 	// if the 2 directives dont match
-	if err := mergeDirectiveListsEqual(value1.Directives, value2.Directives); err != nil {
+	var err error
+	value1Copy.Directives, err = mergeDirectiveLists(value1.Directives, value2.Directives)
+	if err != nil {
 		return nil, fmt.Errorf("conflict in enum value directives: %w", err)
 	}
 
@@ -476,7 +483,8 @@ func mergeFields(field1, field2 *ast.FieldDefinition) (*ast.FieldDefinition, err
 	}
 
 	// directives
-	if err := mergeDirectiveListsEqual(field1.Directives, field2.Directives); err != nil {
+	field1Copy.Directives, err = mergeDirectiveLists(field1.Directives, field2.Directives)
+	if err != nil {
 		return nil, fmt.Errorf("fields are not equal: %w", err)
 	}
 
@@ -484,27 +492,30 @@ func mergeFields(field1, field2 *ast.FieldDefinition) (*ast.FieldDefinition, err
 	return &field1Copy, nil
 }
 
-func mergeDirectiveListsEqual(list1, list2 ast.DirectiveList) error {
-	// if the 2 lists are not the same length
+// mergeDirectiveLists merges list1 with list2 or returns an error for an incompatible merge.
+// A direct list merge is compatible if both lists are identical OR one of the lists is empty.
+func mergeDirectiveLists(list1, list2 ast.DirectiveList) (ast.DirectiveList, error) {
+	// If either list is empty, use the other as the merged list.
+	if len(list1) == 0 {
+		return list2, nil
+	}
+	if len(list2) == 0 {
+		return list1, nil
+	}
+	// Otherwise, validate they're exactly equal before returning one of them.
+	// Reminder that the GraphQL spec says directive order is significant: https://spec.graphql.org/October2021/#sec-Language.Directives.Directive-order-is-significant
+
 	if len(list1) != len(list2) {
 		// they will never be the same
-		return errors.New("there were an inconsistent number of directives")
+		return nil, fmt.Errorf("there were an inconsistent number of directives: %d != %d", len(list1), len(list2))
 	}
 
-	// compare each argument to its counterpart in the other list
-	for _, arg1 := range list1 {
-		arg2 := list2.ForName(arg1.Name)
-		if arg2 == nil {
-			return fmt.Errorf("could not find the directive with name %s", arg1.Name)
-		}
-
-		// if the 2 arguments are not the same
-		if err := mergeDirectiveEqual(arg1, arg2); err != nil {
-			return err
+	for index := range list1 {
+		if err := mergeDirectiveEqual(list1[index], list2[index]); err != nil {
+			return nil, fmt.Errorf("directives at index #%d are not equal (note: order is significant): %w", index, err)
 		}
 	}
-
-	return nil
+	return list1, nil
 }
 
 func mergeDirectiveEqual(directive1, directive2 *ast.Directive) error {
@@ -553,7 +564,7 @@ func mergeArgumentsEqual(arg1, arg2 *ast.Argument) error {
 
 	// if the values are different
 	if err := mergeValuesEqual(arg1.Value, arg2.Value); err != nil {
-		return err
+		return fmt.Errorf("argument %q values are not equal: %w", arg1.Name, err)
 	}
 
 	// they're the same
@@ -621,11 +632,11 @@ func mergeValuesEqual(value1, value2 *ast.Value) error {
 
 	// if the kinds are not the same
 	if value1.Kind != value2.Kind {
-		return errors.New("encountered inconsistent kinds")
+		return fmt.Errorf("encountered inconsistent kinds: %d != %d", value1.Kind, value2.Kind)
 	}
 	// if the raw values are not the same
 	if value1.Raw != value2.Raw {
-		return errors.New("encountered different raw values")
+		return fmt.Errorf("encountered different raw values: %s != %s", value1.Raw, value2.Raw)
 	}
 
 	return nil

--- a/merge.go
+++ b/merge.go
@@ -429,7 +429,7 @@ func mergeScalars(value1, value2 *ast.Definition) (*ast.Definition, error) {
 	var err error
 	value1Copy.Directives, err = mergeDirectiveLists(value1.Directives, value2.Directives)
 	if err != nil {
-		return nil, fmt.Errorf("conflict in enum value directives: %w", err)
+		return nil, fmt.Errorf("conflict in scalar value directives: %w", err)
 	}
 
 	return &value1Copy, nil

--- a/merge.go
+++ b/merge.go
@@ -154,7 +154,7 @@ func mergeSchemas(sources []*ast.Schema) (*ast.Schema, error) {
 			}
 
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%s (%s): %w", definition.Name, definition.Kind, err)
 			}
 			result.Types[name] = previousDefinition
 		}
@@ -178,7 +178,7 @@ func mergeSchemas(sources []*ast.Schema) (*ast.Schema, error) {
 			// we have to merge the 2 directives
 			previousDefinition, err := mergeDirectives(previousDefinition, definition)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("@%s (directive): %w", definition.Name, err)
 			}
 			result.Directives[name] = previousDefinition
 		}
@@ -216,7 +216,7 @@ func mergeInterfaces(previousDefinition *ast.Definition, newDefinition *ast.Defi
 		var err error
 		prevCopy.Fields[ix], err = mergeFields(field, otherField)
 		if err != nil {
-			return nil, fmt.Errorf("encountered error merging interface %v: %w", previousDefinition.Name, err)
+			return nil, fmt.Errorf("field %s: %w", field.Name, err)
 		}
 	}
 
@@ -245,7 +245,7 @@ func mergeObjectTypes(previousDefinition *ast.Definition, newDefinition *ast.Def
 			prevCopy.Fields[prevIndex], err = mergeFields(prevField, newField)
 			if err != nil {
 				//  we don't allow 2 fields that have different types
-				return nil, fmt.Errorf("encountered error merging object %v: %w", previousDefinition.Name, err)
+				return nil, fmt.Errorf("field %s: %w", prevField.Name, err)
 			}
 		} else {
 			// its safe to copy over the definition
@@ -390,13 +390,13 @@ func mergeDirectives(previousDefinition *ast.DirectiveDefinition, newDefinition 
 	var err error
 	result.Locations, err = mergeDirectiveLocations(result.Locations, newDefinition.Locations)
 	if err != nil {
-		return nil, fmt.Errorf("conflict in locations for directive %s: %w", previousDefinition.Name, err)
+		return nil, fmt.Errorf("conflict in locations: %w", err)
 	}
 
 	// make sure the 2 definitions take the same arguments
 	result.Arguments, err = mergeArgumentDefinitionList(result.Arguments, newDefinition.Arguments, result.Position.Src.BuiltIn)
 	if err != nil {
-		return nil, fmt.Errorf("conflict in argument definitions for directive %s: %w", previousDefinition.Name, err)
+		return nil, fmt.Errorf("conflict in arguments: %w", err)
 	}
 
 	// the 2 directives can coexist
@@ -450,7 +450,7 @@ func mergeFieldList(list1, list2 ast.FieldList) (ast.FieldList, error) {
 
 		newField, err := mergeFields(field, otherField)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("field %s: %w", field.Name, err)
 		}
 		list1Copy = append(list1Copy, newField)
 	}

--- a/merge.go
+++ b/merge.go
@@ -304,7 +304,7 @@ func mergeInputObjects(object1, object2 *ast.Definition) (*ast.Definition, error
 		return nil, err
 	}
 
-	return object1, nil
+	return &object1Copy, nil // TODO add tests!!
 }
 
 func mergeStringSliceEquivalent(slice1, slice2 []string) error {

--- a/merge.go
+++ b/merge.go
@@ -304,7 +304,7 @@ func mergeInputObjects(object1, object2 *ast.Definition) (*ast.Definition, error
 		return nil, err
 	}
 
-	return &object1Copy, nil // TODO add tests!!
+	return &object1Copy, nil
 }
 
 func mergeStringSliceEquivalent(slice1, slice2 []string) error {

--- a/merge.go
+++ b/merge.go
@@ -493,29 +493,103 @@ func mergeFields(field1, field2 *ast.FieldDefinition) (*ast.FieldDefinition, err
 }
 
 // mergeDirectiveLists merges list1 with list2 or returns an error for an incompatible merge.
-// A direct list merge is compatible if both lists are identical OR one of the lists is empty.
+//
+// A directive list merge is compatible if any of the following conditions are met:
+//  1. One list is empty
+//  2. One list uses only built-in directives
+//  3. Both lists are identical
 func mergeDirectiveLists(list1, list2 ast.DirectiveList) (ast.DirectiveList, error) {
-	// If either list is empty, use the other as the merged list.
-	if len(list1) == 0 {
-		return list2, nil
-	}
-	if len(list2) == 0 {
-		return list1, nil
-	}
-	// Otherwise, validate they're exactly equal before returning one of them.
-	// Reminder that the GraphQL spec says directive order is significant: https://spec.graphql.org/October2021/#sec-Language.Directives.Directive-order-is-significant
+	ordered1, unordered1 := splitSignificantlyOrderedDirectives(list1)
+	ordered2, unordered2 := splitSignificantlyOrderedDirectives(list2)
 
-	if len(list1) != len(list2) {
-		// they will never be the same
-		return nil, fmt.Errorf("there were an inconsistent number of directives: %s != %s", formatDirectives(list1), formatDirectives(list2))
+	ordered, err := mergeOrderedDirectiveLists(ordered1, ordered2)
+	if err != nil {
+		return nil, err
 	}
+	unordered, err := mergeUnorderedDirectiveLists(unordered1, unordered2)
+	if err != nil {
+		return nil, err
+	}
+	return append(unordered, ordered...), nil
+}
 
-	for index := range list1 {
-		if err := mergeDirectiveEqual(list1[index], list2[index]); err != nil {
-			return nil, fmt.Errorf("directives at index #%d are not equal (note: order is significant): %w", index, err)
+// splitSignificantlyOrderedDirectives splits directives into potentially significant ordering and definitely unordered.
+// The split uses stable ordering, so resulting values retain their original relative order.
+// As a reminder, the GraphQL spec says directive order is significant: https://spec.graphql.org/October2021/#sec-Language.Directives.Directive-order-is-significant
+//
+// Only evaluates built-in directives with full confidence as definitely unordered. All others are potentially ordered.
+// At time of writing, all built-in directives do not have significant ordering.
+func splitSignificantlyOrderedDirectives(directives ast.DirectiveList) (potentiallyOrdered, definitelyUnordered ast.DirectiveList) {
+	for _, d := range directives {
+		if isBuiltInDirective(d.Name) {
+			definitelyUnordered = append(definitelyUnordered, d)
+		} else {
+			potentiallyOrdered = append(potentiallyOrdered, d)
 		}
 	}
-	return list1, nil
+	return
+}
+
+func isBuiltInDirective(name string) bool {
+	switch strings.ToLower(name) {
+	case
+		"deprecated",
+		"include",
+		"skip",
+		"specifiedby":
+		return true
+	default:
+		return false
+	}
+}
+
+// mergeOrderedDirectiveLists validates A is identical to B OR one of them is empty, then returns the merged list.
+// Otherwise returns a merge error.
+func mergeOrderedDirectiveLists(a, b ast.DirectiveList) (ast.DirectiveList, error) {
+	// If either list is empty, use the other as the merged list.
+	if len(a) == 0 {
+		return b, nil
+	}
+	if len(b) == 0 {
+		return a, nil
+	}
+	if len(a) != len(b) {
+		// they will never be the same
+		return nil, fmt.Errorf("directives with potentially significant ordering were not of the same length: %s != %s", formatDirectives(a), formatDirectives(b))
+	}
+	for index := range a {
+		if err := mergeDirectiveEqual(a[index], b[index]); err != nil {
+			return nil, fmt.Errorf("directives with potentially significant ordering at index #%d are not equal: %s != %s: %w", index, formatDirectives(a), formatDirectives(b), err)
+		}
+	}
+	return a, nil
+}
+
+// mergeUnorderedDirectiveLists merges unordered directive lists A and B by throwing away duplicates from B and appending the rest to A.
+//
+// Returns an error if a unique directive is detected that repeats a non-repeatable directive definition.
+func mergeUnorderedDirectiveLists(a, b ast.DirectiveList) (ast.DirectiveList, error) {
+	var uniqueBDirectives ast.DirectiveList
+	for _, bDirective := range b {
+		isUnique := true
+		isRepeatedName := false
+		for _, aDirective := range a {
+			if bDirective.Name == aDirective.Name {
+				isRepeatedName = true
+			}
+			if err := mergeDirectiveEqual(bDirective, aDirective); err == nil {
+				isUnique = false
+				break
+			}
+		}
+		if isUnique {
+			if isRepeatedName && !bDirective.Definition.IsRepeatable {
+				return nil, fmt.Errorf("cannot merge unordered directives in '%s' and '%s': found unique, non-repeatable directive: %s", formatDirectives(a), formatDirectives(b), formatDirective(bDirective))
+			}
+			uniqueBDirectives = append(uniqueBDirectives, bDirective)
+		}
+	}
+	return append(a, uniqueBDirectives...), nil
 }
 
 func mergeDirectiveEqual(directive1, directive2 *ast.Directive) error {

--- a/merge.go
+++ b/merge.go
@@ -3,6 +3,9 @@ package gateway
 import (
 	"errors"
 	"fmt"
+	"iter"
+	"maps"
+	"slices"
 	"sort"
 	"strings"
 
@@ -704,45 +707,45 @@ func mergeTypesEqual(type1, type2 *ast.Type) error {
 //	  INPUT_OBJECT
 //	  INPUT_FIELD_DEFINITION
 func mergeDirectiveLocations(list1, list2 []ast.DirectiveLocation) ([]ast.DirectiveLocation, error) {
-	resultSet := make(map[ast.DirectiveLocation]struct{})
 	executableSet1 := make(map[ast.DirectiveLocation]struct{})
-	// Check "not in the permissive set" (type system locations) rather than the restrictive set (executable locations).
-	// The kinds of locations can expand in future versions of the spec, so we should err on the side
-	// of denying new type system fields instead of allowing new executable fields.
-	for _, l := range list1 {
-		resultSet[l] = struct{}{}
-		if !isTypeSystemDirectiveLocation(l) {
-			executableSet1[l] = struct{}{}
-		}
+	for l := range potentialExecutableDirectiveLocations(list1) {
+		executableSet1[l] = struct{}{}
 	}
 	executableSet2 := make(map[ast.DirectiveLocation]struct{})
+	for l := range potentialExecutableDirectiveLocations(list2) {
+		executableSet2[l] = struct{}{}
+	}
+
+	if onlyLeft, onlyRight, areEqualSets := diffSets(executableSet1, executableSet2); !areEqualSets {
+		return nil, fmt.Errorf("do not have the same executable locations: exclusive to first = %v, exclusive to second = %v", onlyLeft, onlyRight)
+	}
+
+	resultSet := make(map[ast.DirectiveLocation]struct{})
+	for _, l := range list1 {
+		resultSet[l] = struct{}{}
+	}
 	for _, l := range list2 {
 		resultSet[l] = struct{}{}
-		if !isTypeSystemDirectiveLocation(l) {
-			executableSet2[l] = struct{}{}
-		}
 	}
+	return slices.Sorted(maps.Keys(resultSet)), nil
+}
 
-	mismatchErr := fmt.Errorf("do not have the same executable locations: %s", executableDirectiveLocationDiff(executableSet1, executableSet2))
-	for l := range executableSet1 {
-		if _, ok := executableSet2[l]; !ok {
-			return nil, mismatchErr
+// potentialExecutableDirectiveLocations returns likely executable directive locations.
+// Only "likely" because new and unexpected location names should fall back to classifying as a more restrictive executable location.
+//
+// Check "not in the permissive set" (type system locations) rather than the restrictive set (executable locations).
+// The kinds of locations can expand in future versions of the spec, so we should err on the side
+// of denying new type system fields instead of allowing new executable fields.
+func potentialExecutableDirectiveLocations(locations []ast.DirectiveLocation) iter.Seq[ast.DirectiveLocation] {
+	return func(yield func(ast.DirectiveLocation) bool) {
+		for _, l := range locations {
+			if !isTypeSystemDirectiveLocation(l) {
+				if !yield(l) {
+					return
+				}
+			}
 		}
 	}
-	for l := range executableSet2 {
-		if _, ok := executableSet1[l]; !ok {
-			return nil, mismatchErr
-		}
-	}
-
-	var result []ast.DirectiveLocation
-	for l := range resultSet {
-		result = append(result, l)
-	}
-	sort.Slice(result, func(a, b int) bool {
-		return result[a] < result[b]
-	})
-	return result, nil
 }
 
 func isTypeSystemDirectiveLocation(d ast.DirectiveLocation) bool {
@@ -783,4 +786,18 @@ func executableDirectiveLocationDiff(set1, set2 map[ast.DirectiveLocation]struct
 		}
 	}
 	return fmt.Sprintf("these locations are not shared: %s", strings.Join(diff, ", "))
+}
+
+func diffSets[Value comparable](left, right map[Value]struct{}) (onlyLeft, onlyRight []Value, areEqualSets bool) {
+	for value := range left {
+		if _, alsoInRight := right[value]; !alsoInRight {
+			onlyLeft = append(onlyLeft, value)
+		}
+	}
+	for value := range right {
+		if _, alsoInLeft := left[value]; !alsoInLeft {
+			onlyRight = append(onlyRight, value)
+		}
+	}
+	return onlyLeft, onlyRight, len(onlyLeft) == 0 && len(onlyRight) == 0
 }

--- a/merge.go
+++ b/merge.go
@@ -494,12 +494,12 @@ func mergeFields(field1, field2 *ast.FieldDefinition) (*ast.FieldDefinition, err
 
 // mergeDirectiveLists merges list1 with list2 or returns an error for an incompatible merge.
 //
-// A directive list merge is compatible if any of the following conditions are met:
-//  1. One list is empty
-//  2. One list uses only built-in directives
-//  3. Both lists' ordered directives are identical
-//
+// A directive list merge is compatible if ALL of the following conditions are met.
+// Note: ordered1 and ordered2 are list1 and list2 filtered to their ordered directives. Similar for unordered1, unordered2.
 // See [splitSignificantlyOrderedDirectives] for details on "ordered" directives.
+//
+//  1. Both ordered1 and ordered2 are identical OR one is empty. Identical includes their args and relative ordering to one another.
+//  2. unordered1 and unordered2 do not both include the same non-repeatable directive with different arguments. For example, merging '@specifiedBy(url: "foo")' with '@specifiedBy(url: "bar")' will fail because @specifiedBy is not repeatable.
 func mergeDirectiveLists(list1, list2 ast.DirectiveList) (ast.DirectiveList, error) {
 	ordered1, unordered1 := splitSignificantlyOrderedDirectives(list1)
 	ordered2, unordered2 := splitSignificantlyOrderedDirectives(list2)

--- a/merge_test.go
+++ b/merge_test.go
@@ -1903,6 +1903,16 @@ type Biff @baz @foo {
 `,
 			expectErr: `Biff (OBJECT): directives with potentially significant ordering at index #0 are not equal: @foo @baz != @baz @foo: directives do not have the same name`,
 		},
+		{
+			description: "non-repeatable directive used twice with different arguments",
+			schema1: `
+scalar Biff @specifiedBy(url: "foo")
+`,
+			schema2: `
+scalar Biff @specifiedBy(url: "bar")
+`,
+			expectErr: `Biff (SCALAR): conflict in scalar value directives: cannot merge unordered directives in '@specifiedBy(url: "foo")' and '@specifiedBy(url: "bar")': found unique, non-repeatable directive: @specifiedBy(url: "bar")`,
+		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
 			t.Parallel()

--- a/merge_test.go
+++ b/merge_test.go
@@ -84,19 +84,17 @@ func TestMergeSchema_assignMutationType(t *testing.T) {
 	}
 }
 
-func TestMergeSchema_inputTypes(t *testing.T) {
+func TestMergeSchema_inputObjects(t *testing.T) {
 	t.Parallel()
-	// create the first schema
-	originalSchema, err := graphql.LoadSchema(`
-		input Foo {
-			firstName: String!
-		}
-	`)
-	assert.Nil(t, err)
-
-	t.Run("Matching", func(t *testing.T) {
+	t.Run("Matching fields", func(t *testing.T) {
 		t.Parallel()
 		// merge the schema with one that should work
+		originalSchema, err := graphql.LoadSchema(`
+			input Foo {
+				firstName: String!
+			}
+		`)
+		assert.Nil(t, err)
 		schema, err := testMergeSchemas(t, originalSchema, `
 			input Foo {
 				firstName: String!
@@ -117,6 +115,31 @@ func TestMergeSchema_inputTypes(t *testing.T) {
 			t.Errorf("Encountered incorrect number of fields. Expected 1 found %v", len(inputType.Fields))
 			return
 		}
+	})
+
+	t.Run("Mismatched directive lists", func(t *testing.T) {
+		t.Parallel()
+		originalSchema, err := graphql.LoadSchema(`
+			input Foo {
+				firstName: String!
+			}
+		`)
+		require.NoError(t, err)
+		schema, err := testMergeSchemas(t, originalSchema, `
+			directive @bar on INPUT_OBJECT
+			input Foo @bar {
+				firstName: String!
+			}
+		`)
+		require.NoError(t, err)
+		var schemaBuffer bytes.Buffer
+		formatter.NewFormatter(&schemaBuffer).FormatSchema(schema)
+		assert.Contains(t, schemaBuffer.String(), strings.TrimSpace(`
+directive @bar on INPUT_OBJECT
+input Foo @bar {
+	firstName: String!
+}
+		`))
 	})
 
 	// the table we are testing

--- a/merge_test.go
+++ b/merge_test.go
@@ -1512,7 +1512,7 @@ type Query {
 			description: "do not merge executable locations",
 			schema1:     `directive @foo on FIELD | QUERY`,
 			schema2:     `directive @foo on FRAGMENT_DEFINITION | QUERY`,
-			expectErr:   `conflict in locations for directive foo: do not have the same executable locations: these locations are not shared: FIELD`,
+			expectErr:   `conflict in locations for directive foo: do not have the same executable locations: exclusive to first = [FIELD], exclusive to second = [FRAGMENT_DEFINITION]`,
 		},
 		{
 			description: "merge shared executable locations and mixed type system locations",

--- a/merge_test.go
+++ b/merge_test.go
@@ -1567,7 +1567,7 @@ func TestMergeSchema_directives(t *testing.T) {
 		expectErr          string
 	}{
 		{
-			description: "identical directives on type",
+			description: "identical custom directives on type",
 			schema1: `
 directive @foo on OBJECT
 
@@ -1596,7 +1596,7 @@ type Query {
 `,
 		},
 		{
-			description: "directives only on first schema type",
+			description: "custom directives only on first schema type",
 			schema1: `
 directive @foo on OBJECT
 
@@ -1623,7 +1623,7 @@ type Query {
 `,
 		},
 		{
-			description: "directives only on second schema type",
+			description: "custom directives only on second schema type",
 			schema1: `
 type Bar {
 	baz: String
@@ -1650,7 +1650,7 @@ type Query {
 `,
 		},
 		{
-			description: "directives on both schemas type",
+			description: "identical custom directives on both schemas type",
 			schema1: `
 directive @foo on OBJECT
 
@@ -1679,7 +1679,7 @@ type Query {
 `,
 		},
 		{
-			description: "repeated directives on first schemas type",
+			description: "repeated custom directives on first schemas type",
 			schema1: `
 directive @foo repeatable on OBJECT
 
@@ -1706,7 +1706,33 @@ type Query {
 `,
 		},
 		{
-			description: "many repeated and different directives on both schemas type",
+			description: "different built-in and custom directives on both schemas field definition",
+			schema1: `
+type Biff {
+	biff: String @deprecated
+}
+`,
+			schema2: `
+directive @foo on FIELD_DEFINITION
+type Biff {
+	biff: String @foo
+}
+`,
+			expectMergedSchema: `
+directive @foo on FIELD_DEFINITION
+type Biff {
+	biff: String @deprecated @foo
+}
+interface Node {
+	id: ID!
+}
+type Query {
+	node(id: ID!): Node
+}
+`,
+		},
+		{
+			description: "many repeated and unique custom directives on both schemas type",
 			schema1: `
 directive @foo(bar: Int!) repeatable on OBJECT
 directive @baz on OBJECT
@@ -1738,7 +1764,7 @@ type Query {
 `,
 		},
 		{
-			description: "directive lists of different length on both schemas type",
+			description: "custom directive lists of different length on both schemas type",
 			schema1: `
 directive @foo on OBJECT
 directive @baz on OBJECT
@@ -1755,10 +1781,69 @@ type Biff @foo @baz {
 	biff: String
 }
 `,
-			expectErr: `there were an inconsistent number of directives: @foo != @foo @baz`,
+			expectErr: `directives with potentially significant ordering were not of the same length: @foo != @foo @baz`,
 		},
 		{
-			description: "different directive lists of equal length on both schemas type",
+			description: "differently ordered built-in and custom directive lists on different schemas",
+			schema1: `
+directive @foo on FIELD_DEFINITION
+directive @bar on FIELD_DEFINITION
+
+type Biff {
+	biff: String @foo @bar @deprecated
+}
+`,
+			schema2: `
+directive @foo on FIELD_DEFINITION
+directive @bar on FIELD_DEFINITION
+
+type Biff {
+	biff: String @foo @deprecated @bar
+}
+`,
+			expectMergedSchema: `
+directive @bar on FIELD_DEFINITION
+directive @foo on FIELD_DEFINITION
+type Biff {
+	biff: String @deprecated @foo @bar
+}
+interface Node {
+	id: ID!
+}
+type Query {
+	node(id: ID!): Node
+}
+`,
+		},
+		{
+			description: "different built-in and custom directive lists on different schemas",
+			schema1: `
+directive @foo on FIELD_DEFINITION
+
+type Biff {
+	biff: String @foo
+}
+`,
+			schema2: `
+type Biff {
+	biff: String @deprecated
+}
+`,
+			expectMergedSchema: `
+directive @foo on FIELD_DEFINITION
+type Biff {
+	biff: String @deprecated @foo
+}
+interface Node {
+	id: ID!
+}
+type Query {
+	node(id: ID!): Node
+}
+`,
+		},
+		{
+			description: "different custom directive lists of equal length on both schemas type",
 			schema1: `
 directive @foo(bar: Int!) repeatable on OBJECT
 
@@ -1773,10 +1858,10 @@ type Biff @foo(bar: 2) @foo(bar: 1) {
 	biff: String
 }
 `,
-			expectErr: `directives at index #0 are not equal (note: order is significant): argument "bar" values are not equal: encountered different raw values: 1 != 2`,
+			expectErr: `directives with potentially significant ordering at index #0 are not equal: @foo(bar: 1) @foo(bar: 2) != @foo(bar: 2) @foo(bar: 1): argument "bar" values are not equal: encountered different raw values: 1 != 2`,
 		},
 		{
-			description: "differently ordered directive lists of equal length on both schemas type",
+			description: "differently ordered custom directive lists of equal length on both schemas type",
 			schema1: `
 directive @foo on OBJECT
 directive @baz on OBJECT
@@ -1793,7 +1878,7 @@ type Biff @baz @foo {
 	biff: String
 }
 `,
-			expectErr: `directives at index #0 are not equal (note: order is significant): directives do not have the same name`,
+			expectErr: `directives with potentially significant ordering at index #0 are not equal: @foo @baz != @baz @foo: directives do not have the same name`,
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {

--- a/merge_test.go
+++ b/merge_test.go
@@ -1520,7 +1520,7 @@ type Query {
 			description: "do not merge executable locations",
 			schema1:     `directive @foo on FIELD | QUERY`,
 			schema2:     `directive @foo on FRAGMENT_DEFINITION | QUERY`,
-			expectErr:   `conflict in locations for directive foo: do not have the same executable locations: exclusive to first = [FIELD], exclusive to second = [FRAGMENT_DEFINITION]`,
+			expectErr:   `@foo (directive): conflict in locations: do not have the same executable locations: exclusive to first = [FIELD], exclusive to second = [FRAGMENT_DEFINITION]`,
 		},
 		{
 			description: "merge shared executable locations and mixed type system locations",
@@ -1781,7 +1781,7 @@ type Biff @foo @baz {
 	biff: String
 }
 `,
-			expectErr: `directives with potentially significant ordering were not of the same length: @foo != @foo @baz`,
+			expectErr: `Biff (OBJECT): directives with potentially significant ordering were not of the same length: @foo != @foo @baz`,
 		},
 		{
 			description: "differently ordered built-in and custom directive lists on different schemas",
@@ -1858,7 +1858,7 @@ type Biff @foo(bar: 2) @foo(bar: 1) {
 	biff: String
 }
 `,
-			expectErr: `directives with potentially significant ordering at index #0 are not equal: @foo(bar: 1) @foo(bar: 2) != @foo(bar: 2) @foo(bar: 1): argument "bar" values are not equal: encountered different raw values: 1 != 2`,
+			expectErr: `Biff (OBJECT): directives with potentially significant ordering at index #0 are not equal: @foo(bar: 1) @foo(bar: 2) != @foo(bar: 2) @foo(bar: 1): argument "bar" values are not equal: encountered different raw values: 1 != 2`,
 		},
 		{
 			description: "differently ordered custom directive lists of equal length on both schemas type",
@@ -1878,7 +1878,7 @@ type Biff @baz @foo {
 	biff: String
 }
 `,
-			expectErr: `directives with potentially significant ordering at index #0 are not equal: @foo @baz != @baz @foo: directives do not have the same name`,
+			expectErr: `Biff (OBJECT): directives with potentially significant ordering at index #0 are not equal: @foo @baz != @baz @foo: directives do not have the same name`,
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {

--- a/merge_test.go
+++ b/merge_test.go
@@ -1755,7 +1755,7 @@ type Biff @foo @baz {
 	biff: String
 }
 `,
-			expectErr: `there were an inconsistent number of directives: 1 != 2`,
+			expectErr: `there were an inconsistent number of directives: @foo != @foo @baz`,
 		},
 		{
 			description: "different directive lists of equal length on both schemas type",

--- a/merge_test.go
+++ b/merge_test.go
@@ -2,6 +2,8 @@ package gateway
 
 import (
 	"bytes"
+	"iter"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1931,6 +1933,55 @@ scalar Biff @specifiedBy(url: "bar")
 			formatter.NewFormatter(&currentSchemaBuf).FormatSchema(currentSchema)
 			currentSchemaStr := strings.TrimSpace(currentSchemaBuf.String())
 			assert.Equal(t, strings.TrimSpace(tc.expectMergedSchema), currentSchemaStr)
+		})
+	}
+}
+
+func TestDiffSets(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		description                     string
+		left, right                     iter.Seq[int]
+		expectOnlyLeft, expectOnlyRight []int
+		expectAreEqualSets              bool
+	}{
+		{
+			description:        "equal sets",
+			left:               slices.Values([]int{1, 2, 3}),
+			right:              slices.Values([]int{1, 2, 3}),
+			expectAreEqualSets: true,
+		},
+		{
+			description:    "unique in left",
+			left:           slices.Values([]int{1, 2, 3, 4}),
+			right:          slices.Values([]int{1, 2, 3}),
+			expectOnlyLeft: []int{4},
+		},
+		{
+			description:     "unique in right",
+			left:            slices.Values([]int{1, 2, 3}),
+			right:           slices.Values([]int{1, 2, 3, 4}),
+			expectOnlyRight: []int{4},
+		},
+		{
+			description:    "unique in left stable ordering",
+			left:           slices.Values([]int{1, 2, 3, 4}),
+			right:          slices.Values([]int{1, 3}),
+			expectOnlyLeft: []int{2, 4},
+		},
+		{
+			description:     "unique in right stable ordering",
+			left:            slices.Values([]int{1, 3}),
+			right:           slices.Values([]int{1, 2, 3, 4}),
+			expectOnlyRight: []int{2, 4},
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+			onlyLeft, onlyRight, areEqualSets := diffSets(tc.left, tc.right)
+			assert.Equal(t, tc.expectOnlyLeft, onlyLeft)
+			assert.Equal(t, tc.expectOnlyRight, onlyRight)
+			assert.Equal(t, tc.expectAreEqualSets, areEqualSets)
 		})
 	}
 }

--- a/merge_test.go
+++ b/merge_test.go
@@ -151,14 +151,16 @@ func TestMergeSchema_inputTypes(t *testing.T) {
 		{
 			"Conflicting directives",
 			`
-				input Foo {
+				directive @foo on INPUT_OBJECT
+
+				input Foo @foo {
 					lastName: String!
 				}
 			`,
 			`
-				directive @foo on INPUT_OBJECT
+				directive @bar on INPUT_OBJECT
 
-				input Foo @foo {
+				input Foo @bar {
 					lastName: String!
 				}
 			`,
@@ -166,15 +168,17 @@ func TestMergeSchema_inputTypes(t *testing.T) {
 		{
 			"Conflicting field directives",
 			`
+				directive @foo on INPUT_FIELD_DEFINITION
+
 				input Foo {
-					lastName: String!
+					lastName: String! @foo
 				}
 			`,
 			`
-				directive @foo on INPUT_FIELD_DEFINITION
+				directive @bar on INPUT_FIELD_DEFINITION
 
 				input Foo  {
-					lastName: String! @foo
+					lastName: String! @bar
 				}
 			`,
 		},
@@ -277,14 +281,16 @@ func TestMergeSchema_objectTypes(t *testing.T) {
 		{
 			"Conflicting declaration directives",
 			`
-				directive @foo(url: String!) on OBJECT
+				directive @foo on OBJECT
 
-				type User @foo(url: "bar") {
+				type User @foo {
 					firstName: String
 				}
 			`,
 			`
-				type User {
+				directive @bar on OBJECT
+
+				type User @bar {
 					firstName: String
 				}
 			`,
@@ -425,7 +431,7 @@ func TestMergeSchema_enums(t *testing.T) {
 	})
 }
 
-func TestMergeSchema_directives(t *testing.T) {
+func TestMergeSchema_directiveDefinitions(t *testing.T) {
 	t.Parallel()
 	t.Run("Matching", func(t *testing.T) {
 		t.Parallel()
@@ -784,15 +790,17 @@ func TestMergeSchema_interfaces(t *testing.T) {
 		{
 			"Different Field Directives",
 			`
-				interface Foo {
-					name: String!
-				}
-			`,
-			`
 				directive @foo on FIELD_DEFINITION
 
 				interface Foo {
 					name: String! @foo
+				}
+			`,
+			`
+				directive @bar on FIELD_DEFINITION
+
+				interface Foo {
+					name: String! @bar
 				}
 			`,
 		},
@@ -1527,6 +1535,265 @@ type Query {
 	node(id: ID!): Node
 }
 `,
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+			currentSchema, err := graphql.LoadSchema(tc.schema1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			currentSchema, err = testMergeSchemas(t, currentSchema, tc.schema2)
+			if tc.expectErr != "" {
+				assert.EqualError(t, err, tc.expectErr)
+				return
+			}
+			require.NoError(t, err)
+
+			var currentSchemaBuf bytes.Buffer
+			formatter.NewFormatter(&currentSchemaBuf).FormatSchema(currentSchema)
+			currentSchemaStr := strings.TrimSpace(currentSchemaBuf.String())
+			assert.Equal(t, strings.TrimSpace(tc.expectMergedSchema), currentSchemaStr)
+		})
+	}
+}
+
+func TestMergeSchema_directives(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		description        string
+		schema1, schema2   string
+		expectMergedSchema string
+		expectErr          string
+	}{
+		{
+			description: "identical directives on type",
+			schema1: `
+directive @foo on OBJECT
+
+type Bar @foo {
+	baz: String
+}
+`,
+			schema2: `
+directive @foo on OBJECT
+
+type Bar @foo {
+	baz: String
+}
+`,
+			expectMergedSchema: `
+directive @foo on OBJECT
+type Bar @foo {
+	baz: String
+}
+interface Node {
+	id: ID!
+}
+type Query {
+	node(id: ID!): Node
+}
+`,
+		},
+		{
+			description: "directives only on first schema type",
+			schema1: `
+directive @foo on OBJECT
+
+type Bar @foo {
+	baz: String
+}
+`,
+			schema2: `
+type Bar {
+	baz: String
+}
+`,
+			expectMergedSchema: `
+directive @foo on OBJECT
+type Bar @foo {
+	baz: String
+}
+interface Node {
+	id: ID!
+}
+type Query {
+	node(id: ID!): Node
+}
+`,
+		},
+		{
+			description: "directives only on second schema type",
+			schema1: `
+type Bar {
+	baz: String
+}
+`,
+			schema2: `
+directive @foo on OBJECT
+
+type Bar @foo {
+	baz: String
+}
+`,
+			expectMergedSchema: `
+directive @foo on OBJECT
+type Bar @foo {
+	baz: String
+}
+interface Node {
+	id: ID!
+}
+type Query {
+	node(id: ID!): Node
+}
+`,
+		},
+		{
+			description: "directives on both schemas type",
+			schema1: `
+directive @foo on OBJECT
+
+type Bar @foo {
+	baz: String
+}
+`,
+			schema2: `
+directive @foo on OBJECT
+
+type Bar @foo {
+	baz: String
+}
+`,
+			expectMergedSchema: `
+directive @foo on OBJECT
+type Bar @foo {
+	baz: String
+}
+interface Node {
+	id: ID!
+}
+type Query {
+	node(id: ID!): Node
+}
+`,
+		},
+		{
+			description: "repeated directives on first schemas type",
+			schema1: `
+directive @foo repeatable on OBJECT
+
+type Bar @foo @foo {
+	baz: String
+}
+`,
+			schema2: `
+type Bar {
+	baz: String
+}
+`,
+			expectMergedSchema: `
+directive @foo repeatable on OBJECT
+type Bar @foo @foo {
+	baz: String
+}
+interface Node {
+	id: ID!
+}
+type Query {
+	node(id: ID!): Node
+}
+`,
+		},
+		{
+			description: "many repeated and different directives on both schemas type",
+			schema1: `
+directive @foo(bar: Int!) repeatable on OBJECT
+directive @baz on OBJECT
+
+type Biff @foo(bar: 1) @baz @foo(bar: 2) {
+	biff: String
+}
+`,
+			schema2: `
+directive @foo(bar: Int!) repeatable on OBJECT
+directive @baz on OBJECT
+
+type Biff @foo(bar: 1) @baz @foo(bar: 2) {
+	biff: String
+}
+`,
+			expectMergedSchema: `
+directive @baz on OBJECT
+directive @foo(bar: Int!) repeatable on OBJECT
+type Biff @foo(bar: 1) @baz @foo(bar: 2) {
+	biff: String
+}
+interface Node {
+	id: ID!
+}
+type Query {
+	node(id: ID!): Node
+}
+`,
+		},
+		{
+			description: "directive lists of different length on both schemas type",
+			schema1: `
+directive @foo on OBJECT
+directive @baz on OBJECT
+
+type Biff @foo {
+	biff: String
+}
+`,
+			schema2: `
+directive @foo on OBJECT
+directive @baz on OBJECT
+
+type Biff @foo @baz {
+	biff: String
+}
+`,
+			expectErr: `there were an inconsistent number of directives: 1 != 2`,
+		},
+		{
+			description: "different directive lists of equal length on both schemas type",
+			schema1: `
+directive @foo(bar: Int!) repeatable on OBJECT
+
+type Biff @foo(bar: 1) @foo(bar: 2) {
+	biff: String
+}
+`,
+			schema2: `
+directive @foo(bar: Int!) repeatable on OBJECT
+
+type Biff @foo(bar: 2) @foo(bar: 1) {
+	biff: String
+}
+`,
+			expectErr: `directives at index #0 are not equal (note: order is significant): argument "bar" values are not equal: encountered different raw values: 1 != 2`,
+		},
+		{
+			description: "differently ordered directive lists of equal length on both schemas type",
+			schema1: `
+directive @foo on OBJECT
+directive @baz on OBJECT
+
+type Biff @foo @baz {
+	biff: String
+}
+`,
+			schema2: `
+directive @foo on OBJECT
+directive @baz on OBJECT
+
+type Biff @baz @foo {
+	biff: String
+}
+`,
+			expectErr: `directives at index #0 are not equal (note: order is significant): directives do not have the same name`,
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {


### PR DESCRIPTION

Merging directive lists like `scalar Foo @bar @baz @biff` across service schemas can be unnecessarily arduous when the lists are nearly identical.
This change permits some cases to merge cleanly when they do not impact expected behavior.

Critically, the GraphQL spec says [directive order is significant](https://spec.graphql.org/October2021/#sec-Language.Directives.Directive-order-is-significant), so
this change goes through some extra merging pain in gateway to allow more flexible service schemas.

This is most obviously painful when a built-in directive is reused identically across service schemas, like so:
```graphql
scalar Foo @specifiedBy(url: "bar")
scalar Foo @specifiedBy(url: "bar")
```

However, this change also permits custom directives if they are only in one of the services, or are identical.
For example, in the below list of service schemas, A+C and B+C are permitted to merge. Note that A+B cannot be merged because they do not have identical custom directives.
```graphql
scalar Foo @specifiedBy(url: "bar") @baz(biff: 1)
scalar Foo @specifiedBy(url: "bar") @baz(biff: 2)
scalar Foo @specifiedBy(url: "bar")
```

There are other edge cases due to significant ordering, but I've documented those on the relevant functions.


All changes:

* Allow merging slightly dissimilar directive lists
    - Allow non-empty with empty directive lists
    - Permit different sets of definitely-unordered directives. This allows one schema to add @specifiedBy and another a custom directive
* Improve error messages and docs
    - Clarify directive location merge docs
    - Extract helper to identify executable directive locations, improve error message clarity
    - Include mismatched directives in error
    - Fix invalid error message for scalar directive merge
    - Add type, field, and directive names for context on merge errors
* Fix merges for input objects
