### PR TITLE
Fix client $id variable being overwritten in dependent node() steps

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -226,7 +226,7 @@ func executeOneStep(
 		}
 
 		// save the id as a variable to the query
-		variables["id"] = pointData.ID
+		variables[nodeIDVariable] = pointData.ID
 	}
 
 	// if there is no queryer

--- a/execute_test.go
+++ b/execute_test.go
@@ -324,7 +324,7 @@ func TestExecutor_insertIntoFragmentSpread(t *testing.T) {
 								},
 								Queryer: graphql.QueryerFunc(
 									func(input *graphql.QueryInput) (interface{}, error) {
-										assert.Equal(t, map[string]interface{}{"id": "1"}, input.Variables)
+										assert.Equal(t, map[string]interface{}{nodeIDVariable: "1"}, input.Variables)
 										// make sure that we got the right variable inputs
 										return map[string]interface{}{
 											"node": map[string]interface{}{
@@ -459,10 +459,10 @@ func TestExecutor_insertIntoListFragmentSpreads(t *testing.T) {
 								},
 								Queryer: graphql.QueryerFunc(
 									func(input *graphql.QueryInput) (interface{}, error) {
-										assert.Contains(t, []interface{}{"1", "2"}, input.Variables["id"])
+										assert.Contains(t, []interface{}{"1", "2"}, input.Variables[nodeIDVariable])
 										return map[string]interface{}{
 											"node": map[string]interface{}{
-												"address": fmt.Sprintf("address-%s", input.Variables["id"]),
+												"address": fmt.Sprintf("address-%s", input.Variables[nodeIDVariable]),
 											},
 										}, nil
 									},
@@ -603,10 +603,10 @@ func TestExecutor_insertIntoAliasedListFragmentSpreads(t *testing.T) {
 								},
 								Queryer: graphql.QueryerFunc(
 									func(input *graphql.QueryInput) (interface{}, error) {
-										assert.Contains(t, []interface{}{"1", "2"}, input.Variables["id"])
+										assert.Contains(t, []interface{}{"1", "2"}, input.Variables[nodeIDVariable])
 										return map[string]interface{}{
 											"node": map[string]interface{}{
-												"address": fmt.Sprintf("address-%s", input.Variables["id"]),
+												"address": fmt.Sprintf("address-%s", input.Variables[nodeIDVariable]),
 											},
 										}, nil
 									},
@@ -744,10 +744,10 @@ func TestExecutor_insertIntoFragmentSpreadLists(t *testing.T) {
 								},
 								Queryer: graphql.QueryerFunc(
 									func(input *graphql.QueryInput) (interface{}, error) {
-										assert.Contains(t, []interface{}{"1", "2"}, input.Variables["id"])
+										assert.Contains(t, []interface{}{"1", "2"}, input.Variables[nodeIDVariable])
 										return map[string]interface{}{
 											"node": map[string]interface{}{
-												"address": fmt.Sprintf("address-%s", input.Variables["id"]),
+												"address": fmt.Sprintf("address-%s", input.Variables[nodeIDVariable]),
 											},
 										}, nil
 									},
@@ -876,7 +876,7 @@ func TestExecutor_insertIntoInlineFragment(t *testing.T) {
 								},
 								Queryer: graphql.QueryerFunc(
 									func(input *graphql.QueryInput) (interface{}, error) {
-										assert.Equal(t, map[string]interface{}{"id": "1"}, input.Variables)
+										assert.Equal(t, map[string]interface{}{nodeIDVariable: "1"}, input.Variables)
 										// make sure that we got the right variable inputs
 										return map[string]interface{}{
 											"node": map[string]interface{}{
@@ -991,10 +991,10 @@ func TestExecutor_insertIntoListInlineFragments(t *testing.T) {
 								},
 								Queryer: graphql.QueryerFunc(
 									func(input *graphql.QueryInput) (interface{}, error) {
-										assert.Contains(t, []interface{}{"1", "2"}, input.Variables["id"])
+										assert.Contains(t, []interface{}{"1", "2"}, input.Variables[nodeIDVariable])
 										return map[string]interface{}{
 											"node": map[string]interface{}{
-												"address": fmt.Sprintf("address-%s", input.Variables["id"]),
+												"address": fmt.Sprintf("address-%s", input.Variables[nodeIDVariable]),
 											},
 										}, nil
 									},
@@ -1112,10 +1112,10 @@ func TestExecutor_insertIntoInlineFragmentsList(t *testing.T) {
 								},
 								Queryer: graphql.QueryerFunc(
 									func(input *graphql.QueryInput) (interface{}, error) {
-										assert.Contains(t, []interface{}{"1", "2"}, input.Variables["id"])
+										assert.Contains(t, []interface{}{"1", "2"}, input.Variables[nodeIDVariable])
 										return map[string]interface{}{
 											"node": map[string]interface{}{
-												"address": fmt.Sprintf("address-%s", input.Variables["id"]),
+												"address": fmt.Sprintf("address-%s", input.Variables[nodeIDVariable]),
 											},
 										}, nil
 									},
@@ -1306,7 +1306,7 @@ func TestExecutor_insertIntoLists(t *testing.T) {
 										Queryer: graphql.QueryerFunc(
 											func(input *graphql.QueryInput) (interface{}, error) {
 												// make sure that we got the right variable inputs
-												assert.Equal(t, map[string]interface{}{"id": "1"}, input.Variables)
+												assert.Equal(t, map[string]interface{}{nodeIDVariable: "1"}, input.Variables)
 
 												// return the payload
 												return map[string]interface{}{
@@ -1568,7 +1568,7 @@ func TestExecutor_insertIntoAliasedLists(t *testing.T) {
 										Queryer: graphql.QueryerFunc(
 											func(input *graphql.QueryInput) (interface{}, error) {
 												// make sure that we got the right variable inputs
-												assert.Equal(t, map[string]interface{}{"id": "1"}, input.Variables)
+												assert.Equal(t, map[string]interface{}{nodeIDVariable: "1"}, input.Variables)
 
 												// return the payload
 												return map[string]interface{}{

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1012,8 +1012,8 @@ type Foo implements Node {
 				switch url {
 				case fooURL:
 					assert.Equal(t, strings.TrimSpace(`
-query ($id: ID!) {
-	node(id: $id) {
+query ($_gateway_node_id: ID!) {
+	node(id: $_gateway_node_id) {
 		... on Node {
 			... on Foo {
 				id
@@ -1025,8 +1025,8 @@ query ($id: ID!) {
 					return map[string]any{"node": nil}, nil
 				case barURL:
 					assert.Equal(t, strings.TrimSpace(`
-query ($id: ID!) {
-	node(id: $id) {
+query ($_gateway_node_id: ID!) {
+	node(id: $_gateway_node_id) {
 		... on Node {
 			... on Foo {
 				bar
@@ -1138,7 +1138,7 @@ func TestSingleObjectOnlyRequestingNonIDFieldScrubsIDs(t *testing.T) {
 	queryerFactory := QueryerFactory(func(*PlanningContext, string) graphql.Queryer {
 		return graphql.QueryerFunc(func(input *graphql.QueryInput) (any, error) {
 			assert.Equal(t, map[string]any{
-				"id": "foo",
+				nodeIDVariable: "foo",
 			}, input.Variables)
 			return map[string]any{
 				"node": map[string]any{

--- a/plan.go
+++ b/plan.go
@@ -132,6 +132,10 @@ func (p *MinQueriesPlanner) generatePlans(ctx *PlanningContext, query *ast.Query
 	plans := QueryPlanList{}
 
 	for _, operation := range query.Operations {
+		if operation.VariableDefinitions.ForName(nodeIDVariable) != nil {
+			return nil, fmt.Errorf("variable name %q is reserved for internal use by the gateway", nodeIDVariable)
+		}
+
 		// each operation results in a new query
 		plan := &QueryPlan{
 			Operation:           operation,
@@ -932,6 +936,62 @@ func (p *Planner) GetQueryer(ctx *PlanningContext, url string) graphql.Queryer {
 	return graphql.NewSingleRequestQueryer(url)
 }
 
+// nodeIDVariable is necessary to avoid accidentally overwriting the wrong 'id'
+// variable in query planning and execution.
+// Lets take the query below as an example, where favoriteCatPhoto is owned by
+// a second service:
+//
+//	query ($id: ID!, $category: String!) {
+//	  allUsers {
+//	    favoriteCatPhoto(category: $category, owner: $id) { URL }
+//	  }
+//	}
+//
+// The first service needs to run first, so we know the IDs of the users. These
+// are then passed along to the second service. In the query planner, this is
+// known as a dependent step.
+// Before this constant existed, that second query came out like this:
+//
+//	query ($category: String!, $id: ID!) {
+//	    node(id: $id) {
+//	        ... on User {
+//	            favoriteCatPhoto(category: $category, owner: $id) { URL }
+//	        }
+//	    }
+//	}
+//
+// The second query declares the variables its own fields reference, reusing
+// the client's declarations, so $category and $id, both needed by
+// favoriteCatPhoto.
+//
+// That second query gets executed N times, where N=number of users from first
+// query. And each query needs the ID of that user, again coming from the first
+// query:
+//   - 2nd query run #1: $id=u1
+//   - 2nd query run #2: $id=u2
+//   - 2nd query run #3: $id=u3
+//
+// And herein lies the problem: the client's $id was a single fixed value, the
+// one owner they wanted photos from. But each run of the second query
+// overwrites it with the ID of the user currently being resolved, so owner
+// silently becomes u1, then u2, then u3. Instead of one owner's photos, the
+// client gets each user's own.
+//
+// The fix is therefore simple: use a name no client would reasonably pick, and
+// reject the queries that do anyway. The second query now comes out as:
+//
+//	query ($category: String!, $id: ID!, $_gateway_node_id: ID!) {
+//	    node(id: $_gateway_node_id) {
+//	        ... on User {
+//	            favoriteCatPhoto(category: $category, owner: $id) { URL }
+//	        }
+//	    }
+//	}
+//
+// See plannerBuildQuery (declaration), generatePlans (rejection) and
+// executeOneStep (value injection) for the three coupled sites.
+const nodeIDVariable = "_gateway_node_id"
+
 func plannerBuildQuery(ctx *PlanningContext, operationName, parentType string, variables ast.VariableDefinitionList, selectionSet ast.SelectionSet, fragmentDefinitions ast.FragmentDefinitionList) *ast.QueryDocument {
 	ctx.Gateway.logger.Debug("Building Query: \n"+"\tParentType: ", parentType, " ")
 	// build up an operation for the query
@@ -959,7 +1019,7 @@ func plannerBuildQuery(ctx *PlanningContext, operationName, parentType string, v
 
 		// we want the operation to have the equivalent of
 		// {
-		//	 	node(id: $id) {
+		//	 	node(id: $_gateway_node_id) {
 		//	 		... on parentType {
 		//	 			selection
 		//	 		}
@@ -973,7 +1033,7 @@ func plannerBuildQuery(ctx *PlanningContext, operationName, parentType string, v
 						Name: "id",
 						Value: &ast.Value{
 							Kind: ast.Variable,
-							Raw:  "id",
+							Raw:  nodeIDVariable,
 						},
 					},
 				},
@@ -986,13 +1046,10 @@ func plannerBuildQuery(ctx *PlanningContext, operationName, parentType string, v
 			},
 		}
 
-		// if the original query didn't have an id arg we need to add one
-		if variables.ForName("id") == nil {
-			operation.VariableDefinitions = append(operation.VariableDefinitions, &ast.VariableDefinition{
-				Variable: "id",
-				Type:     ast.NonNullNamedType("ID", &ast.Position{}),
-			})
-		}
+		operation.VariableDefinitions = append(operation.VariableDefinitions, &ast.VariableDefinition{
+			Variable: nodeIDVariable,
+			Type:     ast.NonNullNamedType("ID", &ast.Position{}),
+		})
 	}
 
 	// add the operation to a QueryDocument

--- a/plan_test.go
+++ b/plan_test.go
@@ -1267,18 +1267,101 @@ func TestPlanQuery_stepVariables(t *testing.T) {
 		t.Error("Could not find query document")
 		return
 	}
-	// we need to have a query with id and category since id is passed to node
-	if len(nextStep.QueryDocument.Operations[0].VariableDefinitions) != 2 {
-		t.Errorf("Did not find the right number of variable definitions in the next step. Expected 2 found %v", len(nextStep.QueryDocument.Operations[0].VariableDefinitions))
-		return
-	}
-
+	// we need to have a query with id, category, and the gateway's own node id
+	// variable. The client's $id must keep its own definition rather than
+	// being reused for node(id:), or the executor would clobber its value
+	declared := Set{}
 	for _, definition := range nextStep.QueryDocument.Operations[0].VariableDefinitions {
-		if definition.Variable != "id" && definition.Variable != "category" {
-			t.Errorf("Encountered a variable with an unknown name: %v", definition.Variable)
-			return
-		}
+		declared[definition.Variable] = true
 	}
+	assert.Equal(t, Set{"id": true, "category": true, nodeIDVariable: true}, declared)
+}
+
+// TestPlanQuery_clientIDVariableSurvivesNodeStep pins the fix for the
+// collision between the client's variables and the one the gateway uses to
+// carry a dependent step's node id (see [nodeIDVariable])
+func TestPlanQuery_clientIDVariableSurvivesNodeStep(t *testing.T) {
+	t.Parallel()
+
+	locations := FieldURLMap{}
+	locations.RegisterURL(typeNameQuery, "user", "url1")
+	locations.RegisterURL("User", "favoriteCatPhoto", "url2")
+	locations.RegisterURL("CatPhoto", "URL", "url2")
+
+	schema, err := graphql.LoadSchema(`
+		type User {
+			favoriteCatPhoto(category: String!, owner: ID!): CatPhoto!
+		}
+
+		type CatPhoto {
+			URL: String!
+		}
+
+		type Query {
+			user(id: ID!): User
+		}
+	`)
+	require.NoError(t, err)
+
+	plans, err := (&MinQueriesPlanner{}).Plan(&PlanningContext{
+		Query: `
+			query($id: ID!, $category: String!) {
+				user(id: $id) {
+					favoriteCatPhoto(category: $category, owner: $id) {
+						URL
+					}
+				}
+			}
+		`,
+		Schema:    schema,
+		Locations: locations,
+		Gateway:   &Gateway{logger: &DefaultLogger{}},
+	})
+	require.NoError(t, err)
+
+	nextStep := plans[0].RootStep.Then[0].Then[0]
+
+	assert.Contains(t, nextStep.QueryString, "node(id: $"+nodeIDVariable+")")
+	assert.Contains(t, nextStep.QueryString, "owner: $id")
+
+	declared := Set{}
+	for _, definition := range nextStep.QueryDocument.Operations[0].VariableDefinitions {
+		declared[definition.Variable] = true
+	}
+	assert.Equal(t, Set{"id": true, "category": true, nodeIDVariable: true}, declared)
+}
+
+func TestPlanQuery_rejectsReservedNodeIDVariable(t *testing.T) {
+	t.Parallel()
+
+	locations := FieldURLMap{}
+	locations.RegisterURL(typeNameQuery, "user", "url1")
+
+	schema, err := graphql.LoadSchema(`
+		type User {
+			firstName: String!
+		}
+
+		type Query {
+			user(id: ID!): User
+		}
+	`)
+	require.NoError(t, err)
+
+	_, err = (&MinQueriesPlanner{}).Plan(&PlanningContext{
+		Query: `
+			query($` + nodeIDVariable + `: ID!) {
+				user(id: $` + nodeIDVariable + `) {
+					firstName
+				}
+			}
+		`,
+		Schema:    schema,
+		Locations: locations,
+		Gateway:   &Gateway{logger: &DefaultLogger{}},
+	})
+	require.Error(t, err, "expected planning to reject the reserved variable name")
+	assert.Contains(t, err.Error(), "reserved")
 }
 
 func TestPlanQuery_singleFragmentMultipleLocations(t *testing.T) {
@@ -1575,7 +1658,7 @@ func TestPlannerBuildQuery_node(t *testing.T) {
 		t.Error("Did not pass id to the node field")
 		return
 	}
-	if argument.Value.Raw != "id" {
+	if argument.Value.Raw != nodeIDVariable {
 		t.Error("Did not pass the right id value to the node field")
 		return
 	}
@@ -1910,8 +1993,8 @@ func TestPlanQuery_unionShouldNotBeQueriedOnOtherServices(t *testing.T) {
 		case location0:
 			assert.NotContains(t, step.QueryString, "Foo", "Location 0 must not be called with 'Foo' union type")
 			assert.Equal(t, strings.TrimSpace(`
-query ($id: ID!) {
-	node(id: $id) {
+query ($_gateway_node_id: ID!) {
+	node(id: $_gateway_node_id) {
 		... on Bar {
 			bar
 		}


### PR DESCRIPTION
## Summary

Fix bug: when a query spanning two services declared a variable named `$id` and also used it as a field argument in the second service, every dependent `node(id:)` step overwrote the client's value with the ID of the object being resolved. The client's `$id` now keeps its own value.

The ID variable of dependent step queries is now named `_gateway_node_id` instead of `id`.

Any client query that declares a variable `_gateway_node_id` is rejected.

## Longer Explanation

I believe that there is a bug hiding in the way dependent steps are planned and executed.

Let's take the query below:

```graphql
query ($id: ID!, $category: String!) {
  allUsers {
    favoriteCatPhoto(category: $category, owner: $id) {
      URL
    }
  }
}
```

`favoriteCatPhoto` is owned by a second service. The idea behind the request is that `owner: $id` acts like a filter, so we only get cat photos where the owner is set to _one specific ID_ (keep that in mind).

At runtime, the above query results in one query to the service that owns `allUsers` and from that we generate multiple, dependent steps, one for each user. Those dependent steps are sent to the second service in the form of `node(id: ...)` queries.

Those dependent step queries obviously need a user ID. What the code currently does is it checks if the query, as sent by the client, already has an `id` variable. If so, this variable is re-used.

```go
// if the original query didn't have an id arg we need to add one
if variables.ForName("id") == nil {
	operation.VariableDefinitions = append(operation.VariableDefinitions, &ast.VariableDefinition{
		Variable: "id",
		Type:     ast.NonNullNamedType("ID", &ast.Position{}),
	})
}
```

And on the execution side, the node ID is written into the variables under that same name for every dependent step:

```go
// execute.go, executeOneStep
// save the id as a variable to the query
variables["id"] = pointData.ID
```

In this case, this means that the _existing_ `id` variable will be populated with each user's ID.

In the end, we generate the following query:

```graphql
query ($category: String!, $id: ID!) {
  node(id: $id) {
    ... on User {
      favoriteCatPhoto(category: $category, owner: $id) {
        URL
      }
    }
  }
}
```

Both `node(id: $id)` and `owner: $id` now read from the same variable, and the executor sets it to `u1`, then `u2`, then `u3`, one dependent step per user.

The problem here is that the `$id` variable is now ambiguous as to what it does: originally it was meant to be a single user ID, for the filtering, but now it also carries the meaning of "each user's ID". As a result, the client gets back the wrong result.

There's a second error mode: if the client declares `$id: String!`, the reused declaration keeps the client's `String!` type, so the remote rejects `node(id: $id)` against `node(id: ID!)`.

My proposed fix is to use a variable name that's unlikely to conflict, like `_gateway_node_id` (`TestPlanQuery_clientIDVariableSurvivesNodeStep.`). Also add a check that the client query does not already use that variable (`TestPlanQuery_rejectsReservedNodeIDVariable`).
