### PR TITLE
Fix union selection planning regressions from #231

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -18,6 +18,9 @@ const (
 	typeNameQuery        = "Query"
 	typeNameMutation     = "Mutation"
 	typeNameSubscription = "Subscription"
+
+	// typenameField is the introspection field every selection set (including unions) may request
+	typenameField = "__typename"
 )
 
 // Executor is responsible for executing a query plan against the remote

--- a/plan.go
+++ b/plan.go
@@ -317,6 +317,55 @@ type extractSelectionConfig struct {
 	wrapper        ast.SelectionSet
 }
 
+// collectUnionSelections groups the selections of a union field by the type they apply to, so that each
+// group can be planned against that type. Selections inside `... on Member { }` (inline or via a named fragment)
+// are keyed by the member type.
+//
+// __typename is the one field the spec allows directly on a union selection set (and clients like Apollo add
+// it automatically). It is keyed by the union itself, since every service that defines the union can answer it.
+//
+// Inline fragments and named fragments whose type condition is the union itself (`fragment f on Union { }`),
+// or which have no type condition at all (`... @include(if: $x) { }`), also apply to the union. Their selections
+// are flattened into the same groups, so that member fields nested inside them are still planned against the
+// member type rather than the union.
+func (p *MinQueriesPlanner) collectUnionSelections(config *extractSelectionConfig, unionName string, selectionSet ast.SelectionSet, groups map[string]ast.SelectionSet) error {
+	for _, selection := range selectionSet {
+		switch selection := selection.(type) {
+		case *ast.Field:
+			if selection.Name != typenameField {
+				return fmt.Errorf("unsupported field %q inside union %s: unions only support __typename and fragments", selection.Name, unionName)
+			}
+			groups[unionName] = append(groups[unionName], selection)
+		case *ast.InlineFragment:
+			if selection.TypeCondition == "" || selection.TypeCondition == unionName {
+				if err := p.collectUnionSelections(config, unionName, selection.SelectionSet, groups); err != nil {
+					return err
+				}
+				continue
+			}
+			groups[selection.TypeCondition] = append(groups[selection.TypeCondition], selection.SelectionSet...)
+		case *ast.FragmentSpread:
+			fragment := config.step.FragmentDefinitions.ForName(selection.Name)
+			if fragment == nil {
+				fragment = config.plan.FragmentDefinitions.ForName(selection.Name)
+			}
+			if fragment == nil {
+				return fmt.Errorf("could not find definition for fragment: %s", selection.Name)
+			}
+			if fragment.TypeCondition == unionName {
+				if err := p.collectUnionSelections(config, unionName, fragment.SelectionSet, groups); err != nil {
+					return err
+				}
+				continue
+			}
+			groups[fragment.TypeCondition] = append(groups[fragment.TypeCondition], fragment.SelectionSet...)
+		default:
+			return fmt.Errorf("unsupported selection type inside union: %T", selection)
+		}
+	}
+	return nil
+}
+
 func (p *MinQueriesPlanner) extractSelection(ctx *PlanningContext, config *extractSelectionConfig) (ast.SelectionSet, error) {
 	ctx.Gateway.logger.Debug("--- Extracting Selection ---")
 	ctx.Gateway.logger.Debug("Parent location: ", config.parentLocation)
@@ -431,16 +480,9 @@ func (p *MinQueriesPlanner) extractSelection(ctx *PlanningContext, config *extra
 					// For these cases, union selections MUST collapse into selected fragments on the union's named types,
 					// so that each member type's fields are planned against the member type (not the union).
 					// The planned fields are wrapped back into an inline fragment on the member type below.
-					for _, subSelection := range selection.SelectionSet {
-						switch subSelection := subSelection.(type) {
-						case *ast.InlineFragment:
-							subSelectionTypes[subSelection.TypeCondition] = append(subSelectionTypes[subSelection.TypeCondition], subSelection.SelectionSet...)
-						case *ast.FragmentSpread:
-							fragment := config.step.FragmentDefinitions.ForName(selection.Name)
-							subSelectionTypes[fragment.TypeCondition] = append(subSelectionTypes[fragment.TypeCondition], fragment.SelectionSet...)
-						default:
-							return nil, fmt.Errorf("unsupported selection type inside union: %T", subSelection)
-						}
+					err := p.collectUnionSelections(config, fieldTypeName, selection.SelectionSet, subSelectionTypes)
+					if err != nil {
+						return nil, err
 					}
 				} else {
 					subSelectionTypes[fieldTypeName] = selection.SelectionSet

--- a/plan.go
+++ b/plan.go
@@ -419,15 +419,18 @@ func (p *MinQueriesPlanner) extractSelection(ctx *PlanningContext, config *extra
 				}
 
 				ctx.Gateway.logger.Debug("found a thing with a selection. extracting to ", insertionPoint, ". Parent insertion", config.insertionPoint)
-				typeName := coreFieldType(selection).Name()
+				fieldTypeName := coreFieldType(selection).Name()
 				subSelectionTypes := make(map[string]ast.SelectionSet)
-				if ctx.Schema.Types[typeName].Kind == ast.Union {
+				isUnion := ctx.Schema.Types[fieldTypeName].Kind == ast.Union
+				if isUnion {
 					// Union types MUST be object types, and can't have fields of their own:
 					// > GraphQL Unions represent an object that could be one of a list of GraphQL Object types, but provides for no guaranteed fields between those types.
 					// > - https://spec.graphql.org/October2021/#sec-Unions
 					//
 					// Service schemas may not define a union type containing one of their shared types, and querying it on that service would result in an error.
-					// For these cases, union selections MUST collapse into selected fragments on the union's named types.
+					// For these cases, union selections MUST collapse into selected fragments on the union's named types,
+					// so that each member type's fields are planned against the member type (not the union).
+					// The planned fields are wrapped back into an inline fragment on the member type below.
 					for _, subSelection := range selection.SelectionSet {
 						switch subSelection := subSelection.(type) {
 						case *ast.InlineFragment:
@@ -440,7 +443,7 @@ func (p *MinQueriesPlanner) extractSelection(ctx *PlanningContext, config *extra
 						}
 					}
 				} else {
-					subSelectionTypes[typeName] = selection.SelectionSet
+					subSelectionTypes[fieldTypeName] = selection.SelectionSet
 				}
 				var subSelections ast.SelectionSet
 				for typeName, selectionSet := range subSelectionTypes {
@@ -460,6 +463,13 @@ func (p *MinQueriesPlanner) extractSelection(ctx *PlanningContext, config *extra
 					})
 					if err != nil {
 						return nil, err
+					}
+					if isUnion && typeName != fieldTypeName && len(subSelection) > 0 {
+						// Fields of a union member type are only valid inside a fragment on that member type
+						subSelection = ast.SelectionSet{&ast.InlineFragment{
+							TypeCondition: typeName,
+							SelectionSet:  subSelection,
+						}}
 					}
 					subSelections = append(subSelections, subSelection...)
 				}

--- a/plan_test.go
+++ b/plan_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"fmt"
 	"iter"
+	"sort"
 	"strings"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/parser"
 )
 
 func TestPlanQuery_singleRootField(t *testing.T) {
@@ -1921,11 +1923,147 @@ query ($id: ID!) {
 			assert.Equal(t, strings.TrimSpace(`
 query {
 	foo {
-		id
-	}
-}`), strings.TrimSpace(step.QueryString))
+		... on Bar {
+			id
 		}
 	}
+}`), strings.TrimSpace(step.QueryString), "the id needed for the node lookup must stay inside the member type fragment, a union has no id field")
+		}
+	}
+}
+
+// Regression test: when the union field and all of its members' fields live on one service, the planner must
+// send the typed fragments through unchanged. Flattening `... on Bar { bar }` into `bar` produces a query
+// that is invalid against the union type.
+func TestPlanQuery_unionSingleLocationKeepsTypeConditions(t *testing.T) {
+	t.Parallel()
+	schema, err := graphql.LoadSchema(`
+		type Query {
+			foo: Foo!
+		}
+		union Foo = Bar | Baz
+		type Bar {
+			id: ID!
+			bar: String!
+		}
+		type Baz {
+			id: ID!
+			baz: String!
+		}
+	`)
+	require.NoError(t, err)
+
+	const location = "url0"
+	locations := FieldURLMap{}
+	locations.RegisterURL(typeNameQuery, "foo", location)
+	locations.RegisterURL("Bar", "id", location)
+	locations.RegisterURL("Bar", "bar", location)
+	locations.RegisterURL("Baz", "id", location)
+	locations.RegisterURL("Baz", "baz", location)
+
+	plans, err := (&MinQueriesPlanner{}).Plan(&PlanningContext{
+		Query: `
+			query {
+				foo {
+					... on Bar {
+						bar
+					}
+					... on Baz {
+						baz
+					}
+				}
+			}
+		`,
+		Schema:    schema,
+		Locations: locations,
+		Gateway:   &Gateway{logger: &DefaultLogger{}},
+	})
+	require.NoError(t, err)
+
+	assertPlannedQueries(t, map[string][]string{
+		location: {`
+			query {
+				foo {
+					... on Bar {
+						bar
+					}
+					... on Baz {
+						baz
+					}
+				}
+			}
+		`},
+	}, plans)
+}
+
+// assertPlannedQueries asserts that executing the plans sends exactly the expected queries to each
+// downstream service (keyed by URL) and nothing else. Queries are compared ignoring the order of
+// selections within a selection set, because the planner groups union sub-selections by type in a map.
+func assertPlannedQueries(t *testing.T, expected map[string][]string, plans QueryPlanList) {
+	t.Helper()
+	actual := map[string][]string{}
+	for _, plan := range plans {
+		// the root step only fans out to its children and never queries a service itself
+		for _, rootChild := range plan.RootStep.Then {
+			for step := range allSteps(rootChild) {
+				url := step.Queryer.(*graphql.SingleRequestQueryer).URL()
+				actual[url] = append(actual[url], step.QueryString)
+			}
+		}
+	}
+	assert.Equal(t, normalizeQueries(t, expected), normalizeQueries(t, actual))
+}
+
+func normalizeQueries(t *testing.T, queries map[string][]string) map[string][]string {
+	t.Helper()
+	normalized := map[string][]string{}
+	for url, urlQueries := range queries {
+		for _, query := range urlQueries {
+			normalized[url] = append(normalized[url], normalizeQuery(t, query))
+		}
+		sort.Strings(normalized[url])
+	}
+	return normalized
+}
+
+// normalizeQuery parses a GraphQL document, recursively sorts every selection set, and prints it back
+func normalizeQuery(t *testing.T, query string) string {
+	t.Helper()
+	doc, err := parser.ParseQuery(&ast.Source{Input: query})
+	require.NoError(t, err, "query must be valid GraphQL: %s", query)
+	for _, operation := range doc.Operations {
+		sortSelectionSet(operation.SelectionSet)
+	}
+	for _, fragment := range doc.Fragments {
+		sortSelectionSet(fragment.SelectionSet)
+	}
+	printed, err := graphql.PrintQuery(doc)
+	require.NoError(t, err)
+	return strings.TrimSpace(printed)
+}
+
+func sortSelectionSet(selectionSet ast.SelectionSet) {
+	for _, selection := range selectionSet {
+		switch selection := selection.(type) {
+		case *ast.Field:
+			sortSelectionSet(selection.SelectionSet)
+		case *ast.InlineFragment:
+			sortSelectionSet(selection.SelectionSet)
+		}
+	}
+	sort.SliceStable(selectionSet, func(i, j int) bool {
+		return printSelection(selectionSet[i]) < printSelection(selectionSet[j])
+	})
+}
+
+func printSelection(selection ast.Selection) string {
+	printed, err := graphql.PrintQuery(&ast.QueryDocument{
+		Operations: ast.OperationList{{Operation: ast.Query, SelectionSet: ast.SelectionSet{selection}}},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return printed
 }
 
 func allSteps(rootStep *QueryPlanStep) iter.Seq[*QueryPlanStep] {

--- a/plan_test.go
+++ b/plan_test.go
@@ -1956,6 +1956,9 @@ func TestPlanQuery_unionSingleLocationKeepsTypeConditions(t *testing.T) {
 	const location = "url0"
 	locations := FieldURLMap{}
 	locations.RegisterURL(typeNameQuery, "foo", location)
+	for _, typeName := range []string{"Foo", "Bar", "Baz"} {
+		locations.RegisterURL(typeName, typenameField, location)
+	}
 	locations.RegisterURL("Bar", "id", location)
 	locations.RegisterURL("Bar", "bar", location)
 	locations.RegisterURL("Baz", "id", location)
@@ -1965,7 +1968,9 @@ func TestPlanQuery_unionSingleLocationKeepsTypeConditions(t *testing.T) {
 		Query: `
 			query {
 				foo {
+					__typename
 					... on Bar {
+						__typename
 						bar
 					}
 					... on Baz {
@@ -1984,11 +1989,272 @@ func TestPlanQuery_unionSingleLocationKeepsTypeConditions(t *testing.T) {
 		location: {`
 			query {
 				foo {
+					__typename
 					... on Bar {
+						__typename
 						bar
 					}
 					... on Baz {
 						baz
+					}
+				}
+			}
+		`},
+	}, plans)
+}
+
+// unionTestSchemaAndLocations returns a schema with a union type 'Foo' served only by location1,
+// whose member types are shared with location0. Field Bar.bar is unique to location0.
+func unionTestSchemaAndLocations(t *testing.T) (*ast.Schema, FieldURLMap, string, string) {
+	t.Helper()
+	schema, err := graphql.LoadSchema(`
+		type Query {
+			foo: Foo!  # Only in location1
+			node(id: ID!): Node
+		}
+		union Foo = Bar | Baz  # Only in location1
+		interface Node {
+			id: ID!
+		}
+		type Bar implements Node {
+			id: ID!
+			bar: String!  # Only in location0
+		}
+		type Baz implements Node {
+			id: ID!
+		}
+	`)
+	require.NoError(t, err)
+
+	const (
+		location0 = "url0"
+		location1 = "url1"
+	)
+	locations := FieldURLMap{}
+	// location0 registers all shared types (Bar, Baz) but no unions
+	locations.RegisterURL(typeNameQuery, "node", location0)
+	locations.RegisterURL("Node", "id", location0)
+	locations.RegisterURL("Bar", "id", location0)
+	locations.RegisterURL("Bar", "bar", location0) // unique to location0
+	locations.RegisterURL("Baz", "id", location0)
+	locations.RegisterURL("Bar", typenameField, location0)
+	locations.RegisterURL("Baz", typenameField, location0)
+
+	// location1 registers foo union-typed 'Foo' field and all shared types (Bar, Baz)
+	locations.RegisterURL(typeNameQuery, "node", location1)
+	locations.RegisterURL(typeNameQuery, "foo", location1) // unique to location1
+	locations.RegisterURL("Node", "id", location1)
+	locations.RegisterURL("Bar", "id", location1)
+	locations.RegisterURL("Baz", "id", location1)
+	locations.RegisterURL("Foo", typenameField, location1)
+	locations.RegisterURL("Bar", typenameField, location1)
+	locations.RegisterURL("Baz", typenameField, location1)
+
+	return schema, locations, location0, location1
+}
+
+// Regression test: __typename is the only field the GraphQL spec allows directly on a union selection set,
+// and clients like Apollo add it automatically. The planner must accept it and request it from the service
+// that owns the union field, while still collapsing the typed fragments onto their object types.
+func TestPlanQuery_unionAllowsTypenameField(t *testing.T) {
+	t.Parallel()
+	schema, locations, location0, location1 := unionTestSchemaAndLocations(t)
+
+	plans, err := (&MinQueriesPlanner{}).Plan(&PlanningContext{
+		Query: `
+			query {
+				foo {
+					__typename
+					... on Bar {
+						__typename
+						bar
+					}
+					... on Baz {
+						__typename
+						id
+					}
+				}
+			}
+		`,
+		Schema:    schema,
+		Locations: locations,
+		Gateway:   &Gateway{logger: &DefaultLogger{}},
+	})
+	require.NoError(t, err)
+
+	assertPlannedQueries(t, map[string][]string{
+		// the union itself, its __typename, and the ids for the node lookup come from the service owning foo
+		location1: {`
+			query {
+				foo {
+					__typename
+					... on Bar {
+						__typename
+						id
+					}
+					... on Baz {
+						__typename
+						id
+					}
+				}
+			}
+		`},
+		// Bar.bar is only available on location0, which does not know the union Foo
+		location0: {`
+			query ($id: ID!) {
+				node(id: $id) {
+					... on Bar {
+						bar
+					}
+				}
+			}
+		`},
+	}, plans)
+}
+
+// Regression test: a named fragment spread directly on a union field must resolve the fragment by the
+// spread's name (not the parent field's name) and must not panic.
+func TestPlanQuery_unionAllowsFragmentSpread(t *testing.T) {
+	t.Parallel()
+	schema, locations, location0, location1 := unionTestSchemaAndLocations(t)
+
+	plans, err := (&MinQueriesPlanner{}).Plan(&PlanningContext{
+		Query: `
+			query {
+				foo {
+					__typename
+					...barFields
+				}
+			}
+
+			fragment barFields on Bar {
+				bar
+			}
+		`,
+		Schema:    schema,
+		Locations: locations,
+		Gateway:   &Gateway{logger: &DefaultLogger{}},
+	})
+	require.NoError(t, err)
+
+	assertPlannedQueries(t, map[string][]string{
+		location1: {`
+			query {
+				foo {
+					__typename
+					... on Bar {
+						id
+					}
+				}
+			}
+		`},
+		location0: {`
+			query ($id: ID!) {
+				node(id: $id) {
+					... on Bar {
+						bar
+					}
+				}
+			}
+		`},
+	}, plans)
+}
+
+// Regression test: a named fragment declared on the union type itself (a common pattern with Apollo Client) must
+// be treated like selections written directly on the union. Its typed sub-fragments must be planned against
+// the member types, so the id for the node lookup ends up inside `... on Bar`, and the service that does not
+// know the union must not receive `... on Foo`.
+func TestPlanQuery_unionAllowsFragmentSpreadOnUnionType(t *testing.T) {
+	t.Parallel()
+	schema, locations, location0, location1 := unionTestSchemaAndLocations(t)
+
+	plans, err := (&MinQueriesPlanner{}).Plan(&PlanningContext{
+		Query: `
+			query {
+				foo {
+					...fooFields
+				}
+			}
+
+			fragment fooFields on Foo {
+				__typename
+				... on Bar {
+					bar
+				}
+			}
+		`,
+		Schema:    schema,
+		Locations: locations,
+		Gateway:   &Gateway{logger: &DefaultLogger{}},
+	})
+	require.NoError(t, err)
+
+	assertPlannedQueries(t, map[string][]string{
+		location1: {`
+			query {
+				foo {
+					__typename
+					... on Bar {
+						id
+					}
+				}
+			}
+		`},
+		location0: {`
+			query ($id: ID!) {
+				node(id: $id) {
+					... on Bar {
+						bar
+					}
+				}
+			}
+		`},
+	}, plans)
+}
+
+// Regression test: an inline fragment without a type condition applies to the union itself, so its selections
+// are treated as if they were written directly on the union. In practice such a fragment carries a directive
+// (`... @include(if: $x) { }`); directives on fragments inside a union are dropped by the planner, which is a
+// separate, pre-existing gap, so this test leaves the directive out.
+func TestPlanQuery_unionAllowsInlineFragmentWithoutTypeCondition(t *testing.T) {
+	t.Parallel()
+	schema, locations, location0, location1 := unionTestSchemaAndLocations(t)
+
+	plans, err := (&MinQueriesPlanner{}).Plan(&PlanningContext{
+		Query: `
+			query {
+				foo {
+					... {
+						__typename
+						... on Bar {
+							bar
+						}
+					}
+				}
+			}
+		`,
+		Schema:    schema,
+		Locations: locations,
+		Gateway:   &Gateway{logger: &DefaultLogger{}},
+	})
+	require.NoError(t, err)
+
+	assertPlannedQueries(t, map[string][]string{
+		location1: {`
+			query {
+				foo {
+					__typename
+					... on Bar {
+						id
+					}
+				}
+			}
+		`},
+		location0: {`
+			query ($id: ID!) {
+				node(id: $id) {
+					... on Bar {
+						bar
 					}
 				}
 			}


### PR DESCRIPTION
I believe #231 introduced a few regressions in the way union selection sets are planned. We hit the first one in production right after upgrading, and discovered the others along the way.

To be clear: the idea behind #231 is good, and this PR keeps it. So what's the issue then?

Let's take the query below, which is what Apollo Client sends for pretty much any union field, since it adds `__typename` automatically:

```graphql
query {
  foo {
    __typename
    ... on Bar {
      bar
    }
    ... on Baz {
      baz
    }
  }
}
```

### 1. `__typename` on a union is rejected

Since #231 the planner refuses this query:

```json
{
  "errors": [
    {
      "extensions": { "code": "GRAPHQL_VALIDATION_FAILED" },
      "message": "unsupported selection type inside union: *ast.Field"
    }
  ]
}
```

The union branch in `extractSelection` only accepts inline fragments and fragment spreads. Everything else hits the default case:

```go
for _, subSelection := range selection.SelectionSet {
	switch subSelection := subSelection.(type) {
	case *ast.InlineFragment:
		// ...
	case *ast.FragmentSpread:
		// ...
	default:
		return nil, fmt.Errorf("unsupported selection type inside union: %T", subSelection)
	}
}
```

`__typename` is the one field the spec allows directly on a union ([3.8 Unions](https://spec.graphql.org/October2021/#sec-Unions)), so any client that adds it breaks on a union field.

**Fix:** accept `__typename` as a field on the union and request it from the service that owns the union field. Covered by `TestPlanQuery_unionAllowsTypenameField`.

### 2. Member fields are flattened onto the union

Without `__typename` the query works, but is sent to the wrong service. #231 strips the `... on Bar { }` wrapper, plans the inner fields against `Bar`, and then appends the planned fields under `foo` (!):

```graphql
query {
  foo {
    bar
    baz
  }
}
```

That's not valid GraphQL since the union `Foo` has no field `bar`. `gqlparser` reports it as `Cannot query field "bar" on type "Foo"`.

The `id` the planner adds for dependent node lookups has the same problem, which is why the existing test asserted `foo { id }` as the expected query for the union's own service. But the expected query string was itself invalid, so I changed it to `foo { ... on Bar { id } }`.

**Fix:** after planning a member type's selections, wrap them back into `... on Member { }` before adding them to the union field. Selections that belong to the union itself (`__typename`) stay unwrapped. Covered by `TestPlanQuery_unionSingleLocationKeepsTypeConditions`, plus the corrected `TestPlanQuery_unionShouldNotBeQueriedOnOtherServices`.

### 3. Named fragment spreads panic

The spread case looks up the fragment by the parent (`selection`), when it should be `subSelection`:

```go
case *ast.FragmentSpread:
    //                                                  v-- this should be subSelection, not selection
	fragment := config.step.FragmentDefinitions.ForName(selection.Name)
	subSelectionTypes[fragment.TypeCondition] = // ...
```

I also believe that we're missing a lookup on the plan. For example, `groupSelectionSet` first checks the step, then the plan:

```go
			// look up if we already have a definition for this fragment in the step
			defn := config.step.FragmentDefinitions.ForName(selection.Name)

			// if we don't have it
			if defn == nil {
				// look in the operation
				defn = config.plan.FragmentDefinitions.ForName(selection.Name)
				if defn == nil {
					return nil, nil, fmt.Errorf("could not find definition for directive: %s", selection.Name)
				}
			}
```

**Fix:** resolve the spread by `subSelection.Name`, check the step's definitions first and fall back to the operation's, and return an error instead of dereferencing `nil` if neither has it. Covered by `TestPlanQuery_unionAllowsFragmentSpread`.

### 4. Fragments on the union type itself

Fragments don't have to be on a member type. Apollo codebases commonly declare them on the union:

```graphql
query {
  foo {
    ...fooFields
  }
}

fragment fooFields on Foo {
  __typename
  ... on Bar {
    bar
  }
}
```

The same goes for an inline fragment without a type condition (`... @include(if: $x) { ... }`), which also applies to the union. With the spread lookup fixed, these are grouped under the union type and handed to the pre-#231 code path, so they hit both of the problems above at once: the `id` is placed directly on the union (`foo { __typename id }`) and `... on Foo` is sent to a service that doesn't know `Foo`.

**Fix:** when a fragment's type condition is the union itself (or absent), flatten its selections into the same per-type groups, recursively. Member fragments nested inside then get planned against the member type like everything else. Covered by `TestPlanQuery_unionAllowsFragmentSpreadOnUnionType` and `TestPlanQuery_unionAllowsInlineFragmentWithoutTypeCondition`.

### Misc

The new tests use an `assertPlannedQueries` helper that collects the query each step would send, keyed by service URL, and compares that against the expected queries. Comparing the outgoing queries directly is what caught bugs 2 and 4, since the plan structure looked fine while the query strings were invalid. The helper normalizes both sides by sorting every selection set, because the planner groups union selections in a map and the order of the output is not stable otherwise.

One thing I have left alone: directives on the fragments inside a union (`... on Bar @include(if: $x) { bar }`) are dropped when the selection set is flattened into the map. That was already the case after #231 and seemed like a separate issue.