### PR TITLE
Forward operation directives to the services that declare them

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -226,7 +226,7 @@ func executeOneStep(
 		}
 
 		// save the id as a variable to the query
-		variables["id"] = pointData.ID
+		variables[nodeIDVariable] = pointData.ID
 	}
 
 	// if there is no queryer

--- a/execute_test.go
+++ b/execute_test.go
@@ -324,7 +324,7 @@ func TestExecutor_insertIntoFragmentSpread(t *testing.T) {
 								},
 								Queryer: graphql.QueryerFunc(
 									func(input *graphql.QueryInput) (interface{}, error) {
-										assert.Equal(t, map[string]interface{}{"id": "1"}, input.Variables)
+										assert.Equal(t, map[string]interface{}{nodeIDVariable: "1"}, input.Variables)
 										// make sure that we got the right variable inputs
 										return map[string]interface{}{
 											"node": map[string]interface{}{
@@ -459,10 +459,10 @@ func TestExecutor_insertIntoListFragmentSpreads(t *testing.T) {
 								},
 								Queryer: graphql.QueryerFunc(
 									func(input *graphql.QueryInput) (interface{}, error) {
-										assert.Contains(t, []interface{}{"1", "2"}, input.Variables["id"])
+										assert.Contains(t, []interface{}{"1", "2"}, input.Variables[nodeIDVariable])
 										return map[string]interface{}{
 											"node": map[string]interface{}{
-												"address": fmt.Sprintf("address-%s", input.Variables["id"]),
+												"address": fmt.Sprintf("address-%s", input.Variables[nodeIDVariable]),
 											},
 										}, nil
 									},
@@ -603,10 +603,10 @@ func TestExecutor_insertIntoAliasedListFragmentSpreads(t *testing.T) {
 								},
 								Queryer: graphql.QueryerFunc(
 									func(input *graphql.QueryInput) (interface{}, error) {
-										assert.Contains(t, []interface{}{"1", "2"}, input.Variables["id"])
+										assert.Contains(t, []interface{}{"1", "2"}, input.Variables[nodeIDVariable])
 										return map[string]interface{}{
 											"node": map[string]interface{}{
-												"address": fmt.Sprintf("address-%s", input.Variables["id"]),
+												"address": fmt.Sprintf("address-%s", input.Variables[nodeIDVariable]),
 											},
 										}, nil
 									},
@@ -744,10 +744,10 @@ func TestExecutor_insertIntoFragmentSpreadLists(t *testing.T) {
 								},
 								Queryer: graphql.QueryerFunc(
 									func(input *graphql.QueryInput) (interface{}, error) {
-										assert.Contains(t, []interface{}{"1", "2"}, input.Variables["id"])
+										assert.Contains(t, []interface{}{"1", "2"}, input.Variables[nodeIDVariable])
 										return map[string]interface{}{
 											"node": map[string]interface{}{
-												"address": fmt.Sprintf("address-%s", input.Variables["id"]),
+												"address": fmt.Sprintf("address-%s", input.Variables[nodeIDVariable]),
 											},
 										}, nil
 									},
@@ -876,7 +876,7 @@ func TestExecutor_insertIntoInlineFragment(t *testing.T) {
 								},
 								Queryer: graphql.QueryerFunc(
 									func(input *graphql.QueryInput) (interface{}, error) {
-										assert.Equal(t, map[string]interface{}{"id": "1"}, input.Variables)
+										assert.Equal(t, map[string]interface{}{nodeIDVariable: "1"}, input.Variables)
 										// make sure that we got the right variable inputs
 										return map[string]interface{}{
 											"node": map[string]interface{}{
@@ -991,10 +991,10 @@ func TestExecutor_insertIntoListInlineFragments(t *testing.T) {
 								},
 								Queryer: graphql.QueryerFunc(
 									func(input *graphql.QueryInput) (interface{}, error) {
-										assert.Contains(t, []interface{}{"1", "2"}, input.Variables["id"])
+										assert.Contains(t, []interface{}{"1", "2"}, input.Variables[nodeIDVariable])
 										return map[string]interface{}{
 											"node": map[string]interface{}{
-												"address": fmt.Sprintf("address-%s", input.Variables["id"]),
+												"address": fmt.Sprintf("address-%s", input.Variables[nodeIDVariable]),
 											},
 										}, nil
 									},
@@ -1112,10 +1112,10 @@ func TestExecutor_insertIntoInlineFragmentsList(t *testing.T) {
 								},
 								Queryer: graphql.QueryerFunc(
 									func(input *graphql.QueryInput) (interface{}, error) {
-										assert.Contains(t, []interface{}{"1", "2"}, input.Variables["id"])
+										assert.Contains(t, []interface{}{"1", "2"}, input.Variables[nodeIDVariable])
 										return map[string]interface{}{
 											"node": map[string]interface{}{
-												"address": fmt.Sprintf("address-%s", input.Variables["id"]),
+												"address": fmt.Sprintf("address-%s", input.Variables[nodeIDVariable]),
 											},
 										}, nil
 									},
@@ -1306,7 +1306,7 @@ func TestExecutor_insertIntoLists(t *testing.T) {
 										Queryer: graphql.QueryerFunc(
 											func(input *graphql.QueryInput) (interface{}, error) {
 												// make sure that we got the right variable inputs
-												assert.Equal(t, map[string]interface{}{"id": "1"}, input.Variables)
+												assert.Equal(t, map[string]interface{}{nodeIDVariable: "1"}, input.Variables)
 
 												// return the payload
 												return map[string]interface{}{
@@ -1568,7 +1568,7 @@ func TestExecutor_insertIntoAliasedLists(t *testing.T) {
 										Queryer: graphql.QueryerFunc(
 											func(input *graphql.QueryInput) (interface{}, error) {
 												// make sure that we got the right variable inputs
-												assert.Equal(t, map[string]interface{}{"id": "1"}, input.Variables)
+												assert.Equal(t, map[string]interface{}{nodeIDVariable: "1"}, input.Variables)
 
 												// return the payload
 												return map[string]interface{}{

--- a/gateway.go
+++ b/gateway.go
@@ -34,6 +34,10 @@ type Gateway struct {
 
 	// the urls we have to visit to access certain fields
 	fieldURLs FieldURLMap
+
+	// the directives each service declares and where it allows them,
+	// computed once in New by declaredDirectives
+	declaredDirectives map[string]declaredDirectiveSet
 }
 
 // RequestContext holds all of the information required to satisfy the user's query
@@ -232,6 +236,7 @@ func New(sources []*graphql.RemoteSchema, configs ...Option) (*Gateway, error) {
 	// assign the computed values
 	gateway.schema = schema
 	gateway.fieldURLs = urls
+	gateway.declaredDirectives = declaredDirectives(sources)
 	gateway.requestMiddlewares = requestMiddlewares
 	gateway.responseMiddlewares = responseMiddlewares
 
@@ -357,6 +362,85 @@ func fieldURLs(schemas []*graphql.RemoteSchema, stripInternal bool) FieldURLMap 
 
 	// return the location map
 	return locations
+}
+
+// declaredDirectiveSet maps a directive name to the set of locations its
+// declaration allows it in.
+type declaredDirectiveSet map[string]map[ast.DirectiveLocation]bool
+
+// declaredDirectives maps each service url to the directives its schema
+// declares and the locations it allows them in.
+//
+// Several sources can share a url: nothing rejects a gateway configuration
+// that splits one service's schema across two RemoteSchema entries with the
+// same URL, and fieldURLs happily registers fields from both. So when the
+// first entry declares @secret and the second declares @track, the service
+// declares both and the sets have to be unioned. Url-keyed assignment would
+// keep whichever entry came last and silently strip @secret from every query
+// to that service.
+//
+// This reads the source schemas, not the merged one, so it is not affected by
+// how the merger reconciles directive definitions across services.
+func declaredDirectives(schemas []*graphql.RemoteSchema) map[string]declaredDirectiveSet {
+	declared := map[string]declaredDirectiveSet{}
+
+	for _, remoteSchema := range schemas {
+		directives := declared[remoteSchema.URL]
+		if directives == nil {
+			directives = make(declaredDirectiveSet, len(remoteSchema.Schema.Directives))
+			declared[remoteSchema.URL] = directives
+		}
+
+		for name, definition := range remoteSchema.Schema.Directives {
+			locations := directives[name]
+			if locations == nil {
+				locations = make(map[ast.DirectiveLocation]bool, len(definition.Locations))
+				directives[name] = locations
+			}
+
+			for _, location := range definition.Locations {
+				locations[location] = true
+			}
+		}
+	}
+
+	return declared
+}
+
+// directivesFor returns the subset of directives that the service at url
+// declares for the given location. A GraphQL server rejects an entire query
+// that carries a directive it has never heard of, or one in a position its
+// declaration does not allow, so a directive may only travel to the services
+// that can make sense of it there.
+//
+// A url we have no schema for, which covers both the internal schema and the
+// placeholder root step, is sent none.
+func (g *Gateway) directivesFor(url string, location ast.DirectiveLocation, directives ast.DirectiveList) ast.DirectiveList {
+	declared := g.declaredDirectives[url]
+
+	var result ast.DirectiveList
+	for _, directive := range directives {
+		if declared[directive.Name][location] {
+			result = append(result, directive)
+		}
+	}
+
+	return result
+}
+
+// operationDirectiveLocation translates the operation type of a step's query
+// into the directive location a declaration has to allow.
+func operationDirectiveLocation(operation ast.Operation) ast.DirectiveLocation {
+	switch operation {
+	case ast.Query:
+		return ast.LocationQuery
+	case ast.Mutation:
+		return ast.LocationMutation
+	case ast.Subscription:
+		return ast.LocationSubscription
+	default:
+		return ast.LocationQuery
+	}
 }
 
 // FieldURLMap holds the intformation for retrieving the valid locations one can find the value for the field

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/nautilus/graphql"
@@ -1183,4 +1184,128 @@ func TestSingleObjectOnlyRequestingNonIDFieldScrubsIDs(t *testing.T) {
 			},
 		},
 	}, response, "Response must not contain ID fields and not fail while scrubbing them.")
+}
+
+func TestDeclaredDirectives(t *testing.T) {
+	t.Parallel()
+
+	users, err := graphql.LoadSchema(`
+		directive @secret on QUERY | FIELD
+		type Query { user: String }
+	`)
+	require.NoError(t, err)
+
+	posts, err := graphql.LoadSchema(`
+		directive @secret on MUTATION
+		directive @track on QUERY
+		type Query { post: String }
+	`)
+	require.NoError(t, err)
+
+	other, err := graphql.LoadSchema(`
+		type Query { other: String }
+	`)
+	require.NoError(t, err)
+
+	// users and posts are two sources for the same service, so their
+	// declarations are unioned, including the locations of a directive both
+	// declare
+	declared := declaredDirectives([]*graphql.RemoteSchema{
+		{URL: "A", Schema: users},
+		{URL: "A", Schema: posts},
+		{URL: "B", Schema: other},
+	})
+
+	assert.Equal(t, map[ast.DirectiveLocation]bool{
+		ast.LocationQuery:    true,
+		ast.LocationField:    true,
+		ast.LocationMutation: true,
+	}, declared["A"]["secret"])
+	assert.Equal(t, map[ast.DirectiveLocation]bool{ast.LocationQuery: true}, declared["A"]["track"])
+	assert.Nil(t, declared["B"]["secret"])
+	assert.Nil(t, declared["B"]["track"])
+
+	// built-ins come with every schema, so they always travel
+	assert.True(t, declared["B"]["skip"][ast.LocationField])
+	assert.True(t, declared["B"]["include"][ast.LocationInlineFragment])
+
+	// an unknown url is not an error, it just declares nothing
+	assert.Nil(t, declared["C"]["secret"])
+}
+
+func TestOperationDirectivesReachDeclaringService(t *testing.T) {
+	t.Parallel()
+
+	// an operation directive with a variable argument, sent through the http
+	// handler: the declaring service must receive the directive and the
+	// variable, the other service must receive neither
+	const usersURL, postsURL = "users", "posts"
+
+	usersSchema, err := graphql.LoadSchema(`
+		directive @track(session: String) on QUERY
+		type Query { user: String }
+	`)
+	require.NoError(t, err)
+
+	postsSchema, err := graphql.LoadSchema(`
+		type Query { post: String }
+	`)
+	require.NoError(t, err)
+
+	type received struct {
+		Query     string
+		Variables map[string]interface{}
+	}
+	var mu sync.Mutex
+	got := map[string]received{}
+	record := func(url string, input *graphql.QueryInput) {
+		mu.Lock()
+		defer mu.Unlock()
+		got[url] = received{Query: input.Query, Variables: input.Variables}
+	}
+
+	usersService := graphql.QueryerFunc(func(input *graphql.QueryInput) (interface{}, error) {
+		record(usersURL, input)
+		return map[string]interface{}{"user": "u"}, nil
+	})
+	postsService := graphql.QueryerFunc(func(input *graphql.QueryInput) (interface{}, error) {
+		record(postsURL, input)
+		return map[string]interface{}{"post": "p"}, nil
+	})
+
+	queryerFactory := QueryerFactory(func(_ *PlanningContext, url string) graphql.Queryer {
+		if url == usersURL {
+			return usersService
+		}
+		return postsService
+	})
+	gateway, err := New([]*graphql.RemoteSchema{
+		{Schema: usersSchema, URL: usersURL},
+		{Schema: postsSchema, URL: postsURL},
+	}, WithQueryerFactory(&queryerFactory))
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", strings.NewReader(fmt.Sprintf(`
+		{
+			"query": %q,
+			"variables": {"s": "session-1"}
+		}
+	`, `query Name($s: String) @track(session: $s) { user post }`)))
+	resp := httptest.NewRecorder()
+	gateway.GraphQLHandler(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	assert.JSONEq(t, `{"data": {"user": "u", "post": "p"}}`, resp.Body.String())
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, map[string]received{
+		usersURL: {
+			Query:     "query Name ($s: String) @track(session: $s) {\n\tuser\n}\n",
+			Variables: map[string]interface{}{"s": "session-1"},
+		},
+		postsURL: {
+			Query:     "query Name {\n\tpost\n}\n",
+			Variables: map[string]interface{}{},
+		},
+	}, got)
 }

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1012,8 +1012,8 @@ type Foo implements Node {
 				switch url {
 				case fooURL:
 					assert.Equal(t, strings.TrimSpace(`
-query ($id: ID!) {
-	node(id: $id) {
+query ($_gateway_node_id: ID!) {
+	node(id: $_gateway_node_id) {
 		... on Node {
 			... on Foo {
 				id
@@ -1025,8 +1025,8 @@ query ($id: ID!) {
 					return map[string]any{"node": nil}, nil
 				case barURL:
 					assert.Equal(t, strings.TrimSpace(`
-query ($id: ID!) {
-	node(id: $id) {
+query ($_gateway_node_id: ID!) {
+	node(id: $_gateway_node_id) {
 		... on Node {
 			... on Foo {
 				bar
@@ -1138,7 +1138,7 @@ func TestSingleObjectOnlyRequestingNonIDFieldScrubsIDs(t *testing.T) {
 	queryerFactory := QueryerFactory(func(*PlanningContext, string) graphql.Queryer {
 		return graphql.QueryerFunc(func(input *graphql.QueryInput) (any, error) {
 			assert.Equal(t, map[string]any{
-				"id": "foo",
+				nodeIDVariable: "foo",
 			}, input.Variables)
 			return map[string]any{
 				"node": map[string]any{

--- a/plan.go
+++ b/plan.go
@@ -132,6 +132,10 @@ func (p *MinQueriesPlanner) generatePlans(ctx *PlanningContext, query *ast.Query
 	plans := QueryPlanList{}
 
 	for _, operation := range query.Operations {
+		if operation.VariableDefinitions.ForName(nodeIDVariable) != nil {
+			return nil, fmt.Errorf("variable name %q is reserved for internal use by the gateway", nodeIDVariable)
+		}
+
 		// each operation results in a new query
 		plan := &QueryPlan{
 			Operation:           operation,
@@ -932,6 +936,62 @@ func (p *Planner) GetQueryer(ctx *PlanningContext, url string) graphql.Queryer {
 	return graphql.NewSingleRequestQueryer(url)
 }
 
+// nodeIDVariable is necessary to avoid accidentally overwriting the wrong 'id'
+// variable in query planning and execution.
+// Lets take the query below as an example, where favoriteCatPhoto is owned by
+// a second service:
+//
+//	query ($id: ID!, $category: String!) {
+//	  allUsers {
+//	    favoriteCatPhoto(category: $category, owner: $id) { URL }
+//	  }
+//	}
+//
+// The first service needs to run first, so we know the IDs of the users. These
+// are then passed along to the second service. In the query planner, this is
+// known as a dependent step.
+// Before this constant existed, that second query came out like this:
+//
+//	query ($category: String!, $id: ID!) {
+//	    node(id: $id) {
+//	        ... on User {
+//	            favoriteCatPhoto(category: $category, owner: $id) { URL }
+//	        }
+//	    }
+//	}
+//
+// The second query declares the variables its own fields reference, reusing
+// the client's declarations, so $category and $id, both needed by
+// favoriteCatPhoto.
+//
+// That second query gets executed N times, where N=number of users from first
+// query. And each query needs the ID of that user, again coming from the first
+// query:
+//   - 2nd query run #1: $id=u1
+//   - 2nd query run #2: $id=u2
+//   - 2nd query run #3: $id=u3
+//
+// And herein lies the problem: the client's $id was a single fixed value, the
+// one owner they wanted photos from. But each run of the second query
+// overwrites it with the ID of the user currently being resolved, so owner
+// silently becomes u1, then u2, then u3. Instead of one owner's photos, the
+// client gets each user's own.
+//
+// The fix is therefore simple: use a name no client would reasonably pick, and
+// reject the queries that do anyway. The second query now comes out as:
+//
+//	query ($category: String!, $id: ID!, $_gateway_node_id: ID!) {
+//	    node(id: $_gateway_node_id) {
+//	        ... on User {
+//	            favoriteCatPhoto(category: $category, owner: $id) { URL }
+//	        }
+//	    }
+//	}
+//
+// See plannerBuildQuery (declaration), generatePlans (rejection) and
+// executeOneStep (value injection) for the three coupled sites.
+const nodeIDVariable = "_gateway_node_id"
+
 func plannerBuildQuery(ctx *PlanningContext, operationName, parentType string, variables ast.VariableDefinitionList, selectionSet ast.SelectionSet, fragmentDefinitions ast.FragmentDefinitionList) *ast.QueryDocument {
 	ctx.Gateway.logger.Debug("Building Query: \n"+"\tParentType: ", parentType, " ")
 	// build up an operation for the query
@@ -959,7 +1019,7 @@ func plannerBuildQuery(ctx *PlanningContext, operationName, parentType string, v
 
 		// we want the operation to have the equivalent of
 		// {
-		//	 	node(id: $id) {
+		//	 	node(id: $_gateway_node_id) {
 		//	 		... on parentType {
 		//	 			selection
 		//	 		}
@@ -973,7 +1033,7 @@ func plannerBuildQuery(ctx *PlanningContext, operationName, parentType string, v
 						Name: "id",
 						Value: &ast.Value{
 							Kind: ast.Variable,
-							Raw:  "id",
+							Raw:  nodeIDVariable,
 						},
 					},
 				},
@@ -986,13 +1046,10 @@ func plannerBuildQuery(ctx *PlanningContext, operationName, parentType string, v
 			},
 		}
 
-		// if the original query didn't have an id arg we need to add one
-		if variables.ForName("id") == nil {
-			operation.VariableDefinitions = append(operation.VariableDefinitions, &ast.VariableDefinition{
-				Variable: "id",
-				Type:     ast.NonNullNamedType("ID", &ast.Position{}),
-			})
-		}
+		operation.VariableDefinitions = append(operation.VariableDefinitions, &ast.VariableDefinition{
+			Variable: nodeIDVariable,
+			Type:     ast.NonNullNamedType("ID", &ast.Position{}),
+		})
 	}
 
 	// add the operation to a QueryDocument

--- a/plan.go
+++ b/plan.go
@@ -249,6 +249,32 @@ func (p *MinQueriesPlanner) generatePlans(ctx *PlanningContext, query *ast.Query
 				// now that we're done processing the step we need to preconstruct the query that we
 				// will be firing for this plan
 
+				// the operation's directives only travel to the services that
+				// declare them for the operation type this step executes as.
+				// That is the step's own operation type, not the client's: a
+				// dependent step of a mutation re-enters through node(id:),
+				// which is a Query field, so a MUTATION-only directive must
+				// not tag along (see plannerBuildQuery).
+				//
+				// Only the operation position is filtered here. Directives on
+				// fields, fragment spreads, and inline fragments are still
+				// copied verbatim into every step that contains them
+				// (pre-existing behavior), so those still reach services that
+				// never declared them.
+				directives := ctx.Gateway.directivesFor(
+					payload.Location,
+					operationDirectiveLocation(operationForParentType(step.ParentType)),
+					plan.Operation.Directives,
+				)
+
+				// variables referenced by a forwarded directive's arguments
+				// have to be declared and sent along like any field variable
+				for _, directive := range directives {
+					for _, variable := range graphql.ExtractVariables(directive.Arguments) {
+						step.Variables.Add(variable)
+					}
+				}
+
 				// we need to grab the list of variable definitions
 				variableDefs := ast.VariableDefinitionList{}
 				// we need to grab the variable definitions and values for each variable in the step
@@ -258,7 +284,7 @@ func (p *MinQueriesPlanner) generatePlans(ctx *PlanningContext, query *ast.Query
 				}
 
 				// build up the query document
-				step.QueryDocument = plannerBuildQuery(ctx, plan.Operation.Name, step.ParentType, variableDefs, step.SelectionSet, step.FragmentDefinitions)
+				step.QueryDocument = plannerBuildQuery(ctx, plan.Operation.Name, step.ParentType, variableDefs, step.SelectionSet, step.FragmentDefinitions, directives)
 
 				// we also need to turn the query into a string
 				queryString, err := graphql.PrintQuery(step.QueryDocument)
@@ -992,22 +1018,28 @@ func (p *Planner) GetQueryer(ctx *PlanningContext, url string) graphql.Queryer {
 // executeOneStep (value injection) for the three coupled sites.
 const nodeIDVariable = "_gateway_node_id"
 
-func plannerBuildQuery(ctx *PlanningContext, operationName, parentType string, variables ast.VariableDefinitionList, selectionSet ast.SelectionSet, fragmentDefinitions ast.FragmentDefinitionList) *ast.QueryDocument {
+// operationForParentType is the operation type of the query a step executes
+// as: only a step rooted at the top-level mutation or subscription type keeps
+// that operation, every other step is a query (see plannerBuildQuery for why).
+func operationForParentType(parentType string) ast.Operation {
+	switch parentType {
+	case typeNameMutation:
+		return ast.Mutation
+	case typeNameSubscription:
+		return ast.Subscription
+	default:
+		return ast.Query
+	}
+}
+
+func plannerBuildQuery(ctx *PlanningContext, operationName, parentType string, variables ast.VariableDefinitionList, selectionSet ast.SelectionSet, fragmentDefinitions ast.FragmentDefinitionList, directives ast.DirectiveList) *ast.QueryDocument {
 	ctx.Gateway.logger.Debug("Building Query: \n"+"\tParentType: ", parentType, " ")
 	// build up an operation for the query
 	operation := &ast.OperationDefinition{
 		VariableDefinitions: variables,
 		Name:                operationName,
-	}
-
-	// assign the right operation
-	switch parentType {
-	case typeNameMutation:
-		operation.Operation = ast.Mutation
-	case typeNameSubscription:
-		operation.Operation = ast.Subscription
-	default:
-		operation.Operation = ast.Query
+		Directives:          directives,
+		Operation:           operationForParentType(parentType),
 	}
 
 	// if we are querying an operation all we need to do is add the selection set at the root

--- a/plan_test.go
+++ b/plan_test.go
@@ -1579,7 +1579,7 @@ func TestPlannerBuildQuery_query(t *testing.T) {
 
 	// the query we're building goes to the top level Query object
 	ctx := &PlanningContext{Gateway: &Gateway{logger: &DefaultLogger{}}}
-	operation := plannerBuildQuery(ctx, "hoopla", typeNameQuery, variables, selection, ast.FragmentDefinitionList{})
+	operation := plannerBuildQuery(ctx, "hoopla", typeNameQuery, variables, selection, ast.FragmentDefinitionList{}, nil)
 	if operation == nil {
 		t.Error("Did not receive a query.")
 		return
@@ -1620,7 +1620,7 @@ func TestPlannerBuildQuery_node(t *testing.T) {
 
 	// the query we're building goes to the User object
 	ctx := &PlanningContext{Gateway: &Gateway{logger: &DefaultLogger{}}}
-	operation := plannerBuildQuery(ctx, "", objType, ast.VariableDefinitionList{}, selection, ast.FragmentDefinitionList{})
+	operation := plannerBuildQuery(ctx, "", objType, ast.VariableDefinitionList{}, selection, ast.FragmentDefinitionList{}, nil)
 	if operation == nil {
 		t.Error("Did not receive a query.")
 		return
@@ -2027,4 +2027,236 @@ func allStepsRecursive(step *QueryPlanStep, yield func(*QueryPlanStep) bool) boo
 		}
 	}
 	return true
+}
+
+// stepQueriesByURL indexes the queries the planner built for each service, so
+// tests don't depend on step order.
+func stepQueriesByURL(t *testing.T, steps []*QueryPlanStep) map[string]string {
+	t.Helper()
+	queryByService := map[string]string{}
+	for _, step := range steps {
+		queryer, ok := step.Queryer.(*graphql.SingleRequestQueryer)
+		if !ok {
+			t.Fatalf("step has unexpected queryer type %T", step.Queryer)
+		}
+		queryByService[queryer.URL()] = step.QueryString
+	}
+	return queryByService
+}
+
+func TestPlanQuery_operationDirectivesOnlyGoToDeclaringService(t *testing.T) {
+	t.Parallel()
+
+	schemaA, err := graphql.LoadSchema(`
+		directive @secret on QUERY
+		type Query { foo: Boolean }
+	`)
+	require.NoError(t, err)
+
+	schemaB, err := graphql.LoadSchema(`
+		type Query { bar: Boolean }
+	`)
+	require.NoError(t, err)
+
+	gw, err := New([]*graphql.RemoteSchema{
+		{Schema: schemaA, URL: "A"},
+		{Schema: schemaB, URL: "B"},
+	})
+	require.NoError(t, err)
+
+	plans, err := gw.planner.Plan(&PlanningContext{
+		Query:     `query Name @secret { foo bar }`,
+		Schema:    gw.schema,
+		Locations: gw.fieldURLs,
+		Gateway:   gw,
+	})
+	require.NoError(t, err)
+
+	// the plan's root step is only a placeholder; its Then steps hold the
+	// query the planner built for each service
+	assert.Equal(t, map[string]string{
+		"A": "query Name @secret {\n\tfoo\n}\n",
+		"B": "query Name {\n\tbar\n}\n",
+	}, stepQueriesByURL(t, plans[0].RootStep.Then))
+}
+
+func TestPlanQuery_operationDirectivesUnionSourcesSharingURL(t *testing.T) {
+	t.Parallel()
+
+	// one service, configured as two sources that each declare a directive;
+	// the service declares both, so both have to travel
+	schema1, err := graphql.LoadSchema(`
+		directive @secret on QUERY
+		type Query { foo: Boolean }
+	`)
+	require.NoError(t, err)
+
+	schema2, err := graphql.LoadSchema(`
+		directive @track on QUERY
+		type Query { bar: Boolean }
+	`)
+	require.NoError(t, err)
+
+	gw, err := New([]*graphql.RemoteSchema{
+		{Schema: schema1, URL: "A"},
+		{Schema: schema2, URL: "A"},
+	})
+	require.NoError(t, err)
+
+	plans, err := gw.planner.Plan(&PlanningContext{
+		Query:     `query Name @secret @track { foo bar }`,
+		Schema:    gw.schema,
+		Locations: gw.fieldURLs,
+		Gateway:   gw,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, plans[0].RootStep.Then, 1)
+	assert.Equal(t, "query Name @secret @track {\n\tfoo\n\tbar\n}\n", plans[0].RootStep.Then[0].QueryString)
+}
+
+func TestPlanQuery_operationDirectiveVariablesAreForwarded(t *testing.T) {
+	t.Parallel()
+
+	schemaA, err := graphql.LoadSchema(`
+		directive @track(session: String) on QUERY
+		type Query { foo: Boolean }
+	`)
+	require.NoError(t, err)
+
+	schemaB, err := graphql.LoadSchema(`
+		type Query { bar: Boolean }
+	`)
+	require.NoError(t, err)
+
+	gw, err := New([]*graphql.RemoteSchema{
+		{Schema: schemaA, URL: "A"},
+		{Schema: schemaB, URL: "B"},
+	})
+	require.NoError(t, err)
+
+	plans, err := gw.planner.Plan(&PlanningContext{
+		Query:     `query Name($s: String) @track(session: $s) { foo bar }`,
+		Schema:    gw.schema,
+		Locations: gw.fieldURLs,
+		Gateway:   gw,
+	})
+	require.NoError(t, err)
+
+	// the query each service receives and the variables whose values travel
+	// with it at execution time
+	type stepShape struct {
+		Query     string
+		Variables Set
+	}
+
+	stepByService := map[string]stepShape{}
+	for _, step := range plans[0].RootStep.Then {
+		queryer, ok := step.Queryer.(*graphql.SingleRequestQueryer)
+		require.True(t, ok, "step has unexpected queryer type %T", step.Queryer)
+		stepByService[queryer.URL()] = stepShape{Query: step.QueryString, Variables: step.Variables}
+	}
+
+	// the directive travels to A, so $s has to be declared there and its
+	// value has to be sent along at execution time; B gets neither
+	assert.Equal(t, map[string]stepShape{
+		"A": {
+			Query:     "query Name ($s: String) @track(session: $s) {\n\tfoo\n}\n",
+			Variables: Set{"s": true},
+		},
+		"B": {
+			Query:     "query Name {\n\tbar\n}\n",
+			Variables: Set{},
+		},
+	}, stepByService)
+}
+
+func TestPlanQuery_dependentStepsDropMutationOnlyDirectives(t *testing.T) {
+	t.Parallel()
+
+	// both services declare @audit, but only for the MUTATION position. The
+	// dependent step for User.lastName executes as a query against B, so
+	// forwarding @audit by name alone would make B reject it.
+	schemaA, err := graphql.LoadSchema(`
+		directive @audit on MUTATION
+		interface Node { id: ID! }
+		type User implements Node { id: ID! firstName: String! }
+		type Mutation { createUser: User }
+		type Query { node(id: ID!): Node }
+	`)
+	require.NoError(t, err)
+
+	schemaB, err := graphql.LoadSchema(`
+		directive @audit on MUTATION
+		interface Node { id: ID! }
+		type User implements Node { id: ID! lastName: String! }
+		type Query { node(id: ID!): Node }
+	`)
+	require.NoError(t, err)
+
+	gw, err := New([]*graphql.RemoteSchema{
+		{Schema: schemaA, URL: "A"},
+		{Schema: schemaB, URL: "B"},
+	})
+	require.NoError(t, err)
+
+	plans, err := gw.planner.Plan(&PlanningContext{
+		Query:     `mutation Name @audit { createUser { firstName lastName } }`,
+		Schema:    gw.schema,
+		Locations: gw.fieldURLs,
+		Gateway:   gw,
+	})
+	require.NoError(t, err)
+
+	// the mutation step goes to A and keeps the directive; its dependent
+	// step goes to B as a query and has to drop it
+	require.Len(t, plans[0].RootStep.Then, 1)
+	mutationStep := plans[0].RootStep.Then[0]
+	require.Len(t, mutationStep.Then, 1)
+	assert.Equal(t, map[string]string{
+		"mutation step":  "mutation Name @audit {\n\tcreateUser {\n\t\tfirstName\n\t\tid\n\t}\n}\n",
+		"dependent step": "query Name ($_gateway_node_id: ID!) {\n\tnode(id: $_gateway_node_id) {\n\t\t... on User {\n\t\t\tlastName\n\t\t}\n\t}\n}\n",
+	}, map[string]string{
+		"mutation step":  mutationStep.QueryString,
+		"dependent step": mutationStep.Then[0].QueryString,
+	})
+}
+
+func TestPlanQuery_fieldDirectivesStillLeakToNonDeclaringService(t *testing.T) {
+	t.Parallel()
+
+	// Known limitation: only the operation position is filtered. A field
+	// directive is copied into whichever step owns the field, even when that
+	// service never declared it. This test pins the current behavior so the
+	// follow-up that filters field, fragment spread, and inline fragment
+	// positions has something to flip.
+	schemaA, err := graphql.LoadSchema(`
+		directive @secret on FIELD
+		type Query { foo: Boolean }
+	`)
+	require.NoError(t, err)
+
+	schemaB, err := graphql.LoadSchema(`
+		type Query { bar: Boolean }
+	`)
+	require.NoError(t, err)
+
+	gw, err := New([]*graphql.RemoteSchema{
+		{Schema: schemaA, URL: "A"},
+		{Schema: schemaB, URL: "B"},
+	})
+	require.NoError(t, err)
+
+	plans, err := gw.planner.Plan(&PlanningContext{
+		Query:     `query Name { foo bar @secret }`,
+		Schema:    gw.schema,
+		Locations: gw.fieldURLs,
+		Gateway:   gw,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{
+		"A": "query Name {\n\tfoo\n}\n",
+		"B": "query Name {\n\tbar @secret\n}\n",
+	}, stepQueriesByURL(t, plans[0].RootStep.Then))
 }

--- a/plan_test.go
+++ b/plan_test.go
@@ -1267,18 +1267,101 @@ func TestPlanQuery_stepVariables(t *testing.T) {
 		t.Error("Could not find query document")
 		return
 	}
-	// we need to have a query with id and category since id is passed to node
-	if len(nextStep.QueryDocument.Operations[0].VariableDefinitions) != 2 {
-		t.Errorf("Did not find the right number of variable definitions in the next step. Expected 2 found %v", len(nextStep.QueryDocument.Operations[0].VariableDefinitions))
-		return
-	}
-
+	// we need to have a query with id, category, and the gateway's own node id
+	// variable. The client's $id must keep its own definition rather than
+	// being reused for node(id:), or the executor would clobber its value
+	declared := Set{}
 	for _, definition := range nextStep.QueryDocument.Operations[0].VariableDefinitions {
-		if definition.Variable != "id" && definition.Variable != "category" {
-			t.Errorf("Encountered a variable with an unknown name: %v", definition.Variable)
-			return
-		}
+		declared[definition.Variable] = true
 	}
+	assert.Equal(t, Set{"id": true, "category": true, nodeIDVariable: true}, declared)
+}
+
+// TestPlanQuery_clientIDVariableSurvivesNodeStep pins the fix for the
+// collision between the client's variables and the one the gateway uses to
+// carry a dependent step's node id (see [nodeIDVariable])
+func TestPlanQuery_clientIDVariableSurvivesNodeStep(t *testing.T) {
+	t.Parallel()
+
+	locations := FieldURLMap{}
+	locations.RegisterURL(typeNameQuery, "user", "url1")
+	locations.RegisterURL("User", "favoriteCatPhoto", "url2")
+	locations.RegisterURL("CatPhoto", "URL", "url2")
+
+	schema, err := graphql.LoadSchema(`
+		type User {
+			favoriteCatPhoto(category: String!, owner: ID!): CatPhoto!
+		}
+
+		type CatPhoto {
+			URL: String!
+		}
+
+		type Query {
+			user(id: ID!): User
+		}
+	`)
+	require.NoError(t, err)
+
+	plans, err := (&MinQueriesPlanner{}).Plan(&PlanningContext{
+		Query: `
+			query($id: ID!, $category: String!) {
+				user(id: $id) {
+					favoriteCatPhoto(category: $category, owner: $id) {
+						URL
+					}
+				}
+			}
+		`,
+		Schema:    schema,
+		Locations: locations,
+		Gateway:   &Gateway{logger: &DefaultLogger{}},
+	})
+	require.NoError(t, err)
+
+	nextStep := plans[0].RootStep.Then[0].Then[0]
+
+	assert.Contains(t, nextStep.QueryString, "node(id: $"+nodeIDVariable+")")
+	assert.Contains(t, nextStep.QueryString, "owner: $id")
+
+	declared := Set{}
+	for _, definition := range nextStep.QueryDocument.Operations[0].VariableDefinitions {
+		declared[definition.Variable] = true
+	}
+	assert.Equal(t, Set{"id": true, "category": true, nodeIDVariable: true}, declared)
+}
+
+func TestPlanQuery_rejectsReservedNodeIDVariable(t *testing.T) {
+	t.Parallel()
+
+	locations := FieldURLMap{}
+	locations.RegisterURL(typeNameQuery, "user", "url1")
+
+	schema, err := graphql.LoadSchema(`
+		type User {
+			firstName: String!
+		}
+
+		type Query {
+			user(id: ID!): User
+		}
+	`)
+	require.NoError(t, err)
+
+	_, err = (&MinQueriesPlanner{}).Plan(&PlanningContext{
+		Query: `
+			query($` + nodeIDVariable + `: ID!) {
+				user(id: $` + nodeIDVariable + `) {
+					firstName
+				}
+			}
+		`,
+		Schema:    schema,
+		Locations: locations,
+		Gateway:   &Gateway{logger: &DefaultLogger{}},
+	})
+	require.Error(t, err, "expected planning to reject the reserved variable name")
+	assert.Contains(t, err.Error(), "reserved")
 }
 
 func TestPlanQuery_singleFragmentMultipleLocations(t *testing.T) {
@@ -1575,7 +1658,7 @@ func TestPlannerBuildQuery_node(t *testing.T) {
 		t.Error("Did not pass id to the node field")
 		return
 	}
-	if argument.Value.Raw != "id" {
+	if argument.Value.Raw != nodeIDVariable {
 		t.Error("Did not pass the right id value to the node field")
 		return
 	}
@@ -1910,8 +1993,8 @@ func TestPlanQuery_unionShouldNotBeQueriedOnOtherServices(t *testing.T) {
 		case location0:
 			assert.NotContains(t, step.QueryString, "Foo", "Location 0 must not be called with 'Foo' union type")
 			assert.Equal(t, strings.TrimSpace(`
-query ($id: ID!) {
-	node(id: $id) {
+query ($_gateway_node_id: ID!) {
+	node(id: $_gateway_node_id) {
 		... on Bar {
 			bar
 		}


### PR DESCRIPTION
Stacked on #238; the first commit here is that PR. Only the second commit ("forward operation directives to declaring services") is new.

## Summary

Operation directives such as `@bar` in `query Foo @bar { ... }` never reach downstream services and are therefore unusable. This PR forwards each operation directive (+ variables) to the services that declare it and in the correct positions.

## Problem

My team wanted to add a custom operation directive for an opt-in feature and even though the merged schema accepts it and the requests succeed, our service never saw the directives. The feature therefore wasn't working at all.

`TestOperationDirectivesReachDeclaringService` demonstrates the bug end to end. Run against `master`, the response is a 200 but the service receives this:

```diff
  "users": {
-  Query: "query Name ($s: String) @track(session: $s) {\n\tuser\n}\n",
-  Variables: {"s": "session-1"}
+  Query: "query Name {\n\tuser\n}\n",
+  Variables: {}
  }
```

## Change

Two parts: (1) at startup, record which directives each service declares and in which positions; (2) at planning time, attach an operation directive to a step only if the step's service declares it for the position the step executes in, and forward the variables it references.

(1) The directive definitions were already in each `RemoteSchema` passed to `gateway.New`, which is why validation accepted the directive on the way in. What was missing is a per-service record of who declared what. [`declaredDirectives`](https://github.com/amboss-mededu/gateway/blob/7a3c6c7/gateway.go#L384) builds that index once and stores it on the [`Gateway`](https://github.com/amboss-mededu/gateway/blob/7a3c6c7/gateway.go#L18).

(2) When `generatePlans` builds a step's query document, it [filters the client operation's directives](https://github.com/amboss-mededu/gateway/blob/7a3c6c7/plan.go#L264) through [`directivesFor`](https://github.com/amboss-mededu/gateway/blob/7a3c6c7/gateway.go#L418). The filter checks two things: does this step's service declare the directive at all, and does it allow it in the position the step executes in. This matters because a downstream service rejects the entire request if it receives an unknown directive or one in an invalid position.

Variables referenced by a surviving directive are [added to the step's variable set](https://github.com/amboss-mededu/gateway/blob/7a3c6c7/plan.go#L274).

Execution is unchanged.

**The mutation case.** A field owned by a different service than the mutation becomes a dependent step that runs as `node(id:)`, which is a field on `Query`, not on `Mutation` (!). With `directive @audit on MUTATION`, the dependent step of `mutation CreateUser @audit { createUser { firstName lastName } }` must not carry `@audit`, even though the service declares the name. Had it declared `@audit on QUERY | MUTATION`, the step would carry it. [`operationForParentType`](https://github.com/amboss-mededu/gateway/blob/7a3c6c7/plan.go#L1024) is the switch that already lived in `plannerBuildQuery`, extracted so the filter and the query builder share one mapping. `TestPlanQuery_dependentStepsDropMutationOnlyDirectives` covers this.

## Scope

Only the operation position is filtered. Directives on fields, fragment spreads, and inline fragments are still copied verbatim into every step that contains them, which is a pre-existing issue and not touched here.
